### PR TITLE
Fix Android viewport height

### DIFF
--- a/styles/android-fixes.css
+++ b/styles/android-fixes.css
@@ -4,12 +4,11 @@
 
 /* ===== Grundlegende Anpassungen ===== */
 .android-typewriter {
-  height: 100vh;
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  /* Nutze dynamische Viewport-Höhe, damit sich die Ansicht beim Öffnen der
+     Tastatur korrekt anpasst. Ein fixed-Layout führte dazu, dass die aktive
+     Zeile unter der Android‑Tastatur verschwand und der Bildschirm sprang. */
+  min-height: 100dvh;
+  position: relative;
   overflow: hidden;
   -webkit-tap-highlight-color: transparent; /* Entfernt den blauen Highlight-Effekt bei Tap */
   touch-action: manipulation; /* Verbessert Touch-Reaktion */


### PR DESCRIPTION
## Summary
- fix Android layout: replace fixed 100vh body with responsive 100dvh height

## Testing
- `pnpm test` *(fails: no test script)*
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_68598457608883229aee8918e28ea960