### PR TITLE
Enable vertical scrolling in writing area

### DIFF
--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -59,7 +59,7 @@ export default function WritingArea({
   const visibleLines = useVisibleLines(lines, 200, mode, selectedLineIndex, isFullscreen)
 
   return (
-    <div className="flex-1 flex flex-col relative overflow-hidden font-serif">
+    <div className="flex-1 flex flex-col relative overflow-x-hidden overflow-y-auto font-serif">
       <CopyButton lines={lines} activeLine={activeLine} darkMode={darkMode} />
       <NavigationHint darkMode={darkMode} />
 
@@ -71,7 +71,8 @@ export default function WritingArea({
         style={{
           fontSize: `${stackFontSize}px`,
           lineHeight: isFullscreen ? "1.3" : "1.4",
-          overflow: "hidden",
+          overflowY: "auto",
+          overflowX: "hidden",
         }}
         aria-live="polite"
       >

--- a/components/writing-area/LineStack.tsx
+++ b/components/writing-area/LineStack.tsx
@@ -27,7 +27,8 @@ export const LineStack = memo(function LineStack({
     <div
       className="line-stack"
       style={{
-        overflow: "hidden",
+        overflowY: "auto",
+        overflowX: "hidden",
         display: "flex",
         flexDirection: "column",
         justifyContent: mode === "navigating" ? "center" : "flex-end",

--- a/styles/android-fixes.css
+++ b/styles/android-fixes.css
@@ -10,7 +10,8 @@
   left: 0;
   right: 0;
   bottom: 0;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   -webkit-tap-highlight-color: transparent; /* Entfernt den blauen Highlight-Effekt bei Tap */
   touch-action: manipulation; /* Verbessert Touch-Reaktion */
 }


### PR DESCRIPTION
## Summary
- Allow vertical scrolling in WritingArea and LineStack to keep previous lines accessible
- Permit vertical scrolling on Android devices when keyboard is shown

## Testing
- `npm test` *(fails: Cannot find module '../../utils/line-break-utils')*
- `npm run lint` *(prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6891e32ebbf08322a0740747cc0d7069