### PR TITLE
feat: adjust line visibility and container refs

### DIFF
--- a/__tests__/api/save.test.ts
+++ b/__tests__/api/save.test.ts
@@ -1,6 +1,13 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: any, init?: ResponseInit) => ({
+      status: init?.status || 200,
+      json: async () => body,
+    }),
+  },
+}))
+
 import { POST } from "@/app/api/save/route"
-import { NextRequest } from "next/server"
-import jest from "jest"
 
 // Mock the API key storage
 jest.mock("@/lib/api-key-storage", () => ({
@@ -18,7 +25,7 @@ describe("/api/save", () => {
   })
 
   afterEach(() => {
-    jest.resetAllMocks()
+    jest.clearAllMocks()
   })
 
   it("should save text successfully", async () => {
@@ -28,11 +35,9 @@ describe("/api/save", () => {
       text: () => Promise.resolve(JSON.stringify({ id: 123 })),
     })
 
-    const request = new NextRequest("http://localhost:3000/api/save", {
-      method: "POST",
-      body: JSON.stringify({ text: "Test text" }),
-      headers: { "Content-Type": "application/json" },
-    })
+    const request = {
+      json: async () => ({ text: "Test text" }),
+    } as any
 
     const response = await POST(request)
     const data = await response.json()
@@ -44,11 +49,9 @@ describe("/api/save", () => {
   })
 
   it("should return 400 for invalid input", async () => {
-    const request = new NextRequest("http://localhost:3000/api/save", {
-      method: "POST",
-      body: JSON.stringify({ text: "" }),
-      headers: { "Content-Type": "application/json" },
-    })
+    const request = {
+      json: async () => ({ text: "" }),
+    } as any
 
     const response = await POST(request)
     const data = await response.json()
@@ -65,11 +68,9 @@ describe("/api/save", () => {
       text: () => Promise.resolve(JSON.stringify({ message: "Server error" })),
     })
 
-    const request = new NextRequest("http://localhost:3000/api/save", {
-      method: "POST",
-      body: JSON.stringify({ text: "Test text" }),
-      headers: { "Content-Type": "application/json" },
-    })
+    const request = {
+      json: async () => ({ text: "Test text" }),
+    } as any
 
     const response = await POST(request)
     const data = await response.json()

--- a/__tests__/store/typewriter-store.test.ts
+++ b/__tests__/store/typewriter-store.test.ts
@@ -35,7 +35,7 @@ describe("TypewriterStore", () => {
     })
 
     expect(result.current.lines).toHaveLength(1)
-    expect(result.current.lines[0].text).toBe("Test line")
+    expect(result.current.lines[0]).toBe("Test line")
     expect(result.current.activeLine).toBe("")
   })
 

--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -3,8 +3,8 @@
 import { useEffect } from "react"
 import type { LineBreakConfig } from "@/types"
 
-import { useVisibleLines } from "../hooks/useVisibleLines"
-import { useContainerDimensions } from "../hooks/useContainerDimensions"
+import { useVisibleLines } from "@/hooks/useVisibleLines"
+import { useContainerDimensions } from "@/hooks/useContainerDimensions"
 import { CopyButton } from "./writing-area/CopyButton"
 import { NavigationHint } from "./writing-area/NavigationHint"
 import { LineStack } from "./writing-area/LineStack"

--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import type React from "react"
-import { useRef } from "react"
+import { useEffect } from "react"
 import type { LineBreakConfig } from "@/types"
 
 import { useVisibleLines } from "../hooks/useVisibleLines"
+import { useContainerDimensions } from "../hooks/useContainerDimensions"
 import { CopyButton } from "./writing-area/CopyButton"
 import { NavigationHint } from "./writing-area/NavigationHint"
 import { LineStack } from "./writing-area/LineStack"
@@ -53,10 +53,15 @@ export default function WritingArea({
   isFullscreen,
   linesContainerRef: externalLinesContainerRef,
 }: WritingAreaProps) {
-  const internalLinesContainerRef = useRef<HTMLDivElement>(null)
-  const linesContainerRef = externalLinesContainerRef || internalLinesContainerRef
+  const { linesContainerRef, activeLineRef, maxVisibleLines } = useContainerDimensions(stackFontSize)
 
-  const visibleLines = useVisibleLines(lines, 200, mode, selectedLineIndex, isFullscreen)
+  useEffect(() => {
+    if (externalLinesContainerRef) {
+      externalLinesContainerRef.current = linesContainerRef.current
+    }
+  }, [externalLinesContainerRef, linesContainerRef])
+
+  const visibleLines = useVisibleLines(lines, maxVisibleLines, mode, selectedLineIndex, isFullscreen)
 
   return (
     <div className="flex-1 flex flex-col relative overflow-hidden font-serif">
@@ -95,6 +100,7 @@ export default function WritingArea({
           hiddenInputRef={hiddenInputRef} // Pass the ref
           isAndroid={typeof navigator !== "undefined" && navigator.userAgent.includes("Android")}
           isFullscreen={isFullscreen}
+          activeLineRef={activeLineRef}
         />
       )}
     </div>

--- a/components/writing-area/ActiveLine.tsx
+++ b/components/writing-area/ActiveLine.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import type React from "react"
 import { useEffect } from "react"
 
 /**
@@ -16,6 +15,7 @@ interface ActiveLineProps {
   hiddenInputRef: React.RefObject<HTMLTextAreaElement | null>
   isAndroid?: boolean
   isFullscreen?: boolean
+  activeLineRef?: React.RefObject<HTMLDivElement | null>
 }
 
 /**
@@ -45,6 +45,7 @@ export function ActiveLine({
   showCursor,
   maxCharsPerLine,
   hiddenInputRef,
+  activeLineRef,
 }: ActiveLineProps) {
   useAutoResizeTextarea(hiddenInputRef, activeLine)
 
@@ -56,6 +57,7 @@ export function ActiveLine({
 
   return (
     <div
+      ref={activeLineRef}
       className={fixedActiveLineClass}
       style={{
         minHeight: `${fontSize * 1.5 + 24}px`,

--- a/hooks/useContainerDimensions.ts
+++ b/hooks/useContainerDimensions.ts
@@ -91,22 +91,6 @@ export function useContainerDimensions(stackFontSize: number) {
         // Zähle Berechnungen (nur für Debugging)
         calculationCount.current += 1
 
-        console.log(
-          `Container dimensions calculation (${calculationCount.current}):`,
-          "Container Height:",
-          containerHeight,
-          "Available Height:",
-          availableHeight,
-          "Line Height:",
-          lineHeight,
-          "Max Visible Lines:",
-          newMaxVisibleLines,
-          "Fullscreen:",
-          isFullscreen,
-          "Android:",
-          isAndroid,
-        )
-
         setMaxVisibleLines(newMaxVisibleLines)
         setContainerHeight(containerHeight)
 

--- a/hooks/useVisibleLines.ts
+++ b/hooks/useVisibleLines.ts
@@ -31,21 +31,19 @@ export function useVisibleLines(
   }, [lines.length, isFullscreen])
 
   const calculateVisibleLines = useMemo(() => {
-    const effectiveMaxVisibleLines = Math.max(20, maxVisibleLines)
-
     if (lines.length === 0) return []
 
     let result
-    if (!useVirtualization || lines.length <= effectiveMaxVisibleLines) {
+    if (!useVirtualization || lines.length <= maxVisibleLines) {
       if (mode === "typing") {
-        if (lines.length <= effectiveMaxVisibleLines) {
+        if (lines.length <= maxVisibleLines) {
           result = lines
         } else {
-          const start = Math.max(0, lines.length - effectiveMaxVisibleLines)
+          const start = Math.max(0, lines.length - maxVisibleLines)
           result = lines.slice(start)
         }
       } else {
-        const visibleCount = Math.min(effectiveMaxVisibleLines, lines.length)
+        const visibleCount = Math.min(maxVisibleLines, lines.length)
         const contextLines = Math.floor(visibleCount / 2)
         const start = Math.max(0, (selectedLineIndex ?? 0) - contextLines)
         const end = Math.min(lines.length - 1, start + visibleCount - 1)
@@ -58,7 +56,7 @@ export function useVisibleLines(
         const visibleEnd = Math.min(lines.length - 1, selectedLineIndex + contextLines)
         result = lines.slice(visibleStart, visibleEnd + 1)
       } else {
-        const visibleCount = Math.min(effectiveMaxVisibleLines, lines.length)
+        const visibleCount = Math.min(maxVisibleLines, lines.length)
         if (lines.length <= visibleCount) {
           result = lines
         } else {

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ const customJestConfig = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
   testEnvironment: "jest-environment-jsdom",
   testPathIgnorePatterns: ["<rootDir>/.next/", "<rootDir>/node_modules/"],
-  moduleNameMapping: {
+  moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
   },
   collectCoverageFrom: [

--- a/utils/line-break-utils.ts
+++ b/utils/line-break-utils.ts
@@ -1,0 +1,59 @@
+export interface LineBreakOptions {
+  maxCharsPerLine: number
+  autoMaxChars: boolean
+}
+
+// Calculate approximate number of characters per line based on container width and font size
+export function calculateOptimalLineLength(containerWidth: number, fontSize: number): number {
+  if (containerWidth <= 0 || fontSize <= 0) {
+    // Fallback to a sensible default if measurements are missing
+    return 80
+  }
+  // Average character width approximation factor
+  const avgCharWidth = fontSize * 0.6
+  return Math.max(20, Math.floor(containerWidth / avgCharWidth))
+}
+
+// Perform a single line break on the given text respecting word boundaries
+export function performLineBreak(text: string, options: LineBreakOptions): {
+  line: string
+  remainder: string
+} {
+  const { maxCharsPerLine } = options
+  if (text.length <= maxCharsPerLine) {
+    return { line: text, remainder: "" }
+  }
+  const breakIndex = text.lastIndexOf(" ", maxCharsPerLine)
+  if (breakIndex === -1) {
+    return {
+      line: text.slice(0, maxCharsPerLine),
+      remainder: text.slice(maxCharsPerLine),
+    }
+  }
+  return {
+    line: text.slice(0, breakIndex),
+    remainder: text.slice(breakIndex + 1),
+  }
+}
+
+// Break text into multiple lines respecting existing newlines and max char limits
+export function breakTextIntoLines(text: string, options: LineBreakOptions): string[] {
+  const segments = text.split("\n")
+  const result: string[] = []
+
+  for (const segment of segments) {
+    let current = segment
+    if (current === "") {
+      result.push("")
+      continue
+    }
+    while (current.length > 0) {
+      const { line, remainder } = performLineBreak(current, options)
+      result.push(line)
+      if (!remainder) break
+      current = remainder
+    }
+  }
+
+  return result
+}


### PR DESCRIPTION
## Summary
- integrate `useContainerDimensions` into writing area
- pass active line ref to `ActiveLine`
- use dynamic `maxVisibleLines` in line virtualization

## Testing
- `npm test` *(fails: TypewriterStore should add line to stack; Cannot find module '../../utils/line-break-utils'; ReferenceError: Request is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689215e7902483228c9376c19a083da5