### PR TITLE
Expose line indices from visibleLines hook

### DIFF
--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -76,7 +76,7 @@ export default function WritingArea({
         aria-live="polite"
       >
         <LineStack
-          visibleLines={visibleLines.map((line, index) => ({ line, index: lines.indexOf(line) }))}
+          visibleLines={visibleLines}
           darkMode={darkMode}
           stackFontSize={stackFontSize}
           mode={mode}

--- a/components/writing-area/LineStack.tsx
+++ b/components/writing-area/LineStack.tsx
@@ -38,13 +38,13 @@ export const LineStack = memo(function LineStack({
         margin: "0",
       }}
     >
-      {visibleLines.map(({ line, index }) => {
+      {visibleLines.map(({ line, index }, i) => {
         const isSelected = index === selectedLineIndex
         const selectedClass = isSelected
           ? `${darkMode ? "bg-gray-700" : "bg-amber-100"} rounded-md p-1 -m-1 ring-2 ${darkMode ? "ring-blue-500" : "ring-amber-400"}`
           : ""
 
-        const isLastActive = index === visibleLines.length - 1 && mode === "typing"
+        const isLastActive = i === visibleLines.length - 1 && mode === "typing"
         const lastActiveStyle = isLastActive
           ? {
               fontWeight: 500,

--- a/hooks/useVisibleLines.ts
+++ b/hooks/useVisibleLines.ts
@@ -33,37 +33,45 @@ export function useVisibleLines(
   const calculateVisibleLines = useMemo(() => {
     const effectiveMaxVisibleLines = Math.max(20, maxVisibleLines)
 
-    if (lines.length === 0) return []
+    if (lines.length === 0) return [] as { line: string; index: number }[]
 
-    let result
+    let result: { line: string; index: number }[]
     if (!useVirtualization || lines.length <= effectiveMaxVisibleLines) {
       if (mode === "typing") {
         if (lines.length <= effectiveMaxVisibleLines) {
-          result = lines
+          result = lines.map((line, index) => ({ line, index }))
         } else {
           const start = Math.max(0, lines.length - effectiveMaxVisibleLines)
-          result = lines.slice(start)
+          result = lines
+            .slice(start)
+            .map((line, idx) => ({ line, index: start + idx }))
         }
       } else {
         const visibleCount = Math.min(effectiveMaxVisibleLines, lines.length)
         const contextLines = Math.floor(visibleCount / 2)
         const start = Math.max(0, (selectedLineIndex ?? 0) - contextLines)
         const end = Math.min(lines.length - 1, start + visibleCount - 1)
-        result = lines.slice(start, end + 1)
+        result = lines
+          .slice(start, end + 1)
+          .map((line, idx) => ({ line, index: start + idx }))
       }
     } else {
       if (mode === "navigating" && selectedLineIndex !== null) {
         const contextLines = isFullscreen ? 20 : isAndroid ? 15 : 10
         const visibleStart = Math.max(0, selectedLineIndex - contextLines)
         const visibleEnd = Math.min(lines.length - 1, selectedLineIndex + contextLines)
-        result = lines.slice(visibleStart, visibleEnd + 1)
+        result = lines
+          .slice(visibleStart, visibleEnd + 1)
+          .map((line, idx) => ({ line, index: visibleStart + idx }))
       } else {
         const visibleCount = Math.min(effectiveMaxVisibleLines, lines.length)
         if (lines.length <= visibleCount) {
-          result = lines
+          result = lines.map((line, index) => ({ line, index }))
         } else {
           const visibleStart = Math.max(0, lines.length - visibleCount)
-          result = lines.slice(visibleStart)
+          result = lines
+            .slice(visibleStart)
+            .map((line, idx) => ({ line, index: visibleStart + idx }))
         }
       }
     }


### PR DESCRIPTION
## Summary
- return `{line, index}` objects from `useVisibleLines` to expose original line positions
- simplify `WritingArea` by passing hook output directly to `LineStack`
- update `LineStack` to consume `{line, index}` entries and track last active line correctly

## Testing
- `npm test` *(fails: Cannot find module '../../utils/line-break-utils'; ReferenceError: Request is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689231c881a48322bf3ca255602bcced