### PR TITLE
fix: enforce header height

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -192,7 +192,7 @@ export default function TypewriterPage() {
     >
       <ApiKeyWarning />
       <header
-        className={`border-b ${
+        className={`h-10 border-b ${
           darkMode ? "border-gray-700" : "border-[#d3d0cb]"
         } transition-colors duration-300 flex-shrink-0`}
       >

--- a/components/control-bar.tsx
+++ b/components/control-bar.tsx
@@ -277,7 +277,7 @@ function ControlBar({
   // Standard-Layout
   return (
     <div
-      className={`flex flex-wrap gap-2 sm:gap-4 items-center justify-between p-2 sm:p-3 ${
+      className={`flex h-full items-center justify-between gap-2 sm:gap-4 px-2 sm:px-3 ${
         darkMode ? "text-gray-200 bg-gray-900" : "text-[#222] bg-[#f3efe9]"
       } text-sm font-sans`}
     >


### PR DESCRIPTION
## Summary
- fix header to a consistent 40px height
- adjust ControlBar layout to flex center within fixed header

## Testing
- `npm test` (fails: Cannot find module '../../utils/line-break-utils', ReferenceError: Request is not defined)
- `npm run lint` (fails: asks interactive config)

------
https://chatgpt.com/codex/tasks/task_e_689231cb7d088322ac6e8aabc4981977