### PR TITLE
Compute dynamic visible lines

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,9 +35,13 @@ export default function TypewriterPage() {
     handleKeyPress,
   } = useTypewriterStore()
 
-  const containerRef = useRef<HTMLDivElement>(null)
+  const viewportRef = useRef<HTMLDivElement>(null)
+  const headerRef = useRef<HTMLElement>(null)
+  const activeLineRef = useRef<HTMLDivElement>(null)
   const hiddenInputRef = useRef<HTMLTextAreaElement>(null)
   const linesContainerRef = useRef<HTMLDivElement>(null) // Ref für den Text-Container
+
+  const [maxVisibleLines, setMaxVisibleLines] = useState(200)
 
   const [showCursor, setShowCursor] = useState(true)
   const [isFullscreen, setIsFullscreen] = useState(false)
@@ -149,6 +153,30 @@ export default function TypewriterPage() {
       if (linesContainerRef.current) {
         setContainerWidth(linesContainerRef.current.clientWidth)
       }
+
+      const viewportHeight = viewportRef.current?.clientHeight ?? window.innerHeight
+      const inputHeight = activeLineRef.current?.offsetHeight ?? 0
+      const optionsHeight = headerRef.current?.offsetHeight ?? 0
+
+      let lineHeight = 0
+      if (linesContainerRef.current) {
+        const stackLine = (linesContainerRef.current.querySelector(
+          ".line-stack div",
+        ) as HTMLElement | null) ||
+          (linesContainerRef.current.querySelector(
+            ".line-stack",
+          ) as HTMLElement | null)
+        if (stackLine) {
+          lineHeight = parseFloat(getComputedStyle(stackLine).lineHeight)
+        }
+      }
+      if (lineHeight) {
+        const maxLines = Math.floor(
+          (viewportHeight - inputHeight - optionsHeight) / lineHeight,
+        )
+        setMaxVisibleLines(maxLines)
+      }
+
       if (typeof window !== "undefined") {
         setOrientation(window.innerWidth > window.innerHeight ? "landscape" : "portrait")
         setIsSmallScreen(window.innerWidth < 768)
@@ -167,7 +195,7 @@ export default function TypewriterPage() {
 
   const toggleFullscreen = useCallback(() => {
     if (!document.fullscreenElement) {
-      containerRef.current?.requestFullscreen().catch((err) => console.error("Fullscreen error:", err))
+      viewportRef.current?.requestFullscreen().catch((err) => console.error("Fullscreen error:", err))
     } else {
       document.exitFullscreen().catch((err) => console.error("Exit fullscreen error:", err))
     }
@@ -183,7 +211,7 @@ export default function TypewriterPage() {
 
   return (
     <div
-      ref={containerRef}
+      ref={viewportRef}
       className={`min-h-screen flex flex-col typewriter-container font-sans outline-none ${
         darkMode ? "dark bg-[#121212] text-[#E0E0E0]" : "bg-[#f3efe9] text-gray-900"
       }`}
@@ -192,6 +220,7 @@ export default function TypewriterPage() {
     >
       <ApiKeyWarning />
       <header
+        ref={headerRef}
         className={`border-b ${
           darkMode ? "border-gray-700" : "border-[#d3d0cb]"
         } transition-colors duration-300 flex-shrink-0`}
@@ -226,6 +255,8 @@ export default function TypewriterPage() {
             selectedLineIndex={selectedLineIndex}
             isFullscreen={isFullscreen}
             linesContainerRef={linesContainerRef}
+            maxVisibleLines={maxVisibleLines}
+            activeLineRef={activeLineRef}
           />
         </section>
       </main>

--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -30,6 +30,8 @@ interface WritingAreaProps {
   selectedLineIndex: number | null
   isFullscreen: boolean
   linesContainerRef?: React.RefObject<HTMLDivElement>
+  maxVisibleLines: number
+  activeLineRef?: React.RefObject<HTMLDivElement>
 }
 
 /**
@@ -52,11 +54,13 @@ export default function WritingArea({
   selectedLineIndex,
   isFullscreen,
   linesContainerRef: externalLinesContainerRef,
+  maxVisibleLines,
+  activeLineRef,
 }: WritingAreaProps) {
   const internalLinesContainerRef = useRef<HTMLDivElement>(null)
   const linesContainerRef = externalLinesContainerRef || internalLinesContainerRef
 
-  const visibleLines = useVisibleLines(lines, 200, mode, selectedLineIndex, isFullscreen)
+  const visibleLines = useVisibleLines(lines, maxVisibleLines, mode, selectedLineIndex, isFullscreen)
 
   return (
     <div className="flex-1 flex flex-col relative overflow-hidden font-serif">
@@ -93,6 +97,7 @@ export default function WritingArea({
           showCursor={showCursor}
           maxCharsPerLine={maxCharsPerLine}
           hiddenInputRef={hiddenInputRef} // Pass the ref
+          activeLineRef={activeLineRef}
           isAndroid={typeof navigator !== "undefined" && navigator.userAgent.includes("Android")}
           isFullscreen={isFullscreen}
         />

--- a/components/writing-area/ActiveLine.tsx
+++ b/components/writing-area/ActiveLine.tsx
@@ -16,6 +16,7 @@ interface ActiveLineProps {
   hiddenInputRef: React.RefObject<HTMLTextAreaElement | null>
   isAndroid?: boolean
   isFullscreen?: boolean
+  activeLineRef?: React.RefObject<HTMLDivElement>
 }
 
 /**
@@ -45,6 +46,7 @@ export function ActiveLine({
   showCursor,
   maxCharsPerLine,
   hiddenInputRef,
+  activeLineRef,
 }: ActiveLineProps) {
   useAutoResizeTextarea(hiddenInputRef, activeLine)
 
@@ -56,6 +58,7 @@ export function ActiveLine({
 
   return (
     <div
+      ref={activeLineRef}
       className={fixedActiveLineClass}
       style={{
         minHeight: `${fontSize * 1.5 + 24}px`,


### PR DESCRIPTION
## Summary
- compute maxVisibleLines dynamically using viewport, header, and active line heights
- forward calculated maxVisibleLines through WritingArea to useVisibleLines
- provide refs for active line and header for measurement

## Testing
- `npm test` *(fails: Cannot find module '../../utils/line-break-utils'; ReferenceError: Request is not defined; TypewriterStore should add line to stack)*

------
https://chatgpt.com/codex/tasks/task_e_6892464b40e483228f872ef3f239d2f9