### PR TITLE
Simplify visible line calculation

### DIFF
--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -56,7 +56,7 @@ export default function WritingArea({
   const internalLinesContainerRef = useRef<HTMLDivElement>(null)
   const linesContainerRef = externalLinesContainerRef || internalLinesContainerRef
 
-  const visibleLines = useVisibleLines(lines, 200, mode, selectedLineIndex, isFullscreen)
+  const visibleLines = useVisibleLines(lines, 200, mode, selectedLineIndex)
 
   return (
     <div className="flex-1 flex flex-col relative overflow-hidden font-serif">

--- a/hooks/useVisibleLines.ts
+++ b/hooks/useVisibleLines.ts
@@ -1,75 +1,32 @@
 "use client"
 
-import { useState, useEffect, useMemo } from "react"
+import { useMemo } from "react"
 
 /**
- * Hook zur Berechnung der sichtbaren Zeilen mit Virtualisierung für bessere Performance
- * Besonders wichtig für leistungsschwächere Android-Geräte
+ * Hook zur Berechnung der sichtbaren Zeilen.
  *
- * @param lines - Array aller Zeilen
- * @param maxVisibleLines - Maximale Anzahl sichtbarer Zeilen
- * @param mode - Aktueller Modus (typing oder navigating)
- * @param selectedLineIndex - Index der ausgewählten Zeile im Navigationsmodus
- * @param isFullscreen - Ob der Vollbildmodus aktiv ist
- * @returns Die aktuell sichtbaren Zeilen
+ * - Im Tippmodus werden einfach die letzten `maxVisibleLines` Zeilen zurückgegeben.
+ * - Im Navigationsmodus wird ein Fenster von `maxVisibleLines` Zeilen um den
+ *   `selectedLineIndex` zentriert zurückgegeben.
  */
 export function useVisibleLines(
   lines: string[],
   maxVisibleLines: number,
   mode: "typing" | "navigating",
   selectedLineIndex: number | null,
-  isFullscreen = false,
 ) {
-  const [isAndroid, setIsAndroid] = useState(false)
-  const [useVirtualization, setUseVirtualization] = useState(false)
-
-  useEffect(() => {
-    const isAndroidDevice = navigator.userAgent.includes("Android")
-    setIsAndroid(isAndroidDevice)
-    const threshold = isFullscreen ? 200 : isAndroidDevice ? 100 : 80
-    setUseVirtualization(lines.length > threshold)
-  }, [lines.length, isFullscreen])
-
-  const calculateVisibleLines = useMemo(() => {
-    const effectiveMaxVisibleLines = Math.max(20, maxVisibleLines)
-
-    if (lines.length === 0) return []
-
-    let result
-    if (!useVirtualization || lines.length <= effectiveMaxVisibleLines) {
-      if (mode === "typing") {
-        if (lines.length <= effectiveMaxVisibleLines) {
-          result = lines
-        } else {
-          const start = Math.max(0, lines.length - effectiveMaxVisibleLines)
-          result = lines.slice(start)
-        }
-      } else {
-        const visibleCount = Math.min(effectiveMaxVisibleLines, lines.length)
-        const contextLines = Math.floor(visibleCount / 2)
-        const start = Math.max(0, (selectedLineIndex ?? 0) - contextLines)
-        const end = Math.min(lines.length - 1, start + visibleCount - 1)
-        result = lines.slice(start, end + 1)
-      }
-    } else {
-      if (mode === "navigating" && selectedLineIndex !== null) {
-        const contextLines = isFullscreen ? 20 : isAndroid ? 15 : 10
-        const visibleStart = Math.max(0, selectedLineIndex - contextLines)
-        const visibleEnd = Math.min(lines.length - 1, selectedLineIndex + contextLines)
-        result = lines.slice(visibleStart, visibleEnd + 1)
-      } else {
-        const visibleCount = Math.min(effectiveMaxVisibleLines, lines.length)
-        if (lines.length <= visibleCount) {
-          result = lines
-        } else {
-          const visibleStart = Math.max(0, lines.length - visibleCount)
-          result = lines.slice(visibleStart)
-        }
-      }
+  return useMemo(() => {
+    if (mode === "typing" || selectedLineIndex === null) {
+      return lines.slice(-maxVisibleLines)
     }
 
-    return result
-  }, [lines, maxVisibleLines, mode, selectedLineIndex, useVirtualization, isAndroid, isFullscreen])
+    const half = Math.floor(maxVisibleLines / 2)
+    const maxStart = Math.max(0, lines.length - maxVisibleLines)
+    let start = selectedLineIndex - half
+    if (start < 0) start = 0
+    if (start > maxStart) start = maxStart
+    const end = start + maxVisibleLines
 
-  return calculateVisibleLines
+    return lines.slice(start, end)
+  }, [lines, maxVisibleLines, mode, selectedLineIndex])
 }


### PR DESCRIPTION
## Summary
- Refactor `useVisibleLines` to return the latest lines in typing mode and a centered window in navigating mode
- Drop virtualization logic and unused arguments, simplifying the hook
- Update `WritingArea` to use new hook signature

## Testing
- `npm test` *(fails: Request is not defined, missing module line-break-utils, line-stack store test)*

------
https://chatgpt.com/codex/tasks/task_e_6892465445048322ade6f222ce0897e2