### PR TITLE
Wrap writing area lines and active line in flex container

### DIFF
--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -58,45 +58,46 @@ export default function WritingArea({
 
   const visibleLines = useVisibleLines(lines, 200, mode, selectedLineIndex, isFullscreen)
 
-  return (
-    <div className="flex-1 flex flex-col relative overflow-hidden font-serif">
-      <CopyButton lines={lines} activeLine={activeLine} darkMode={darkMode} />
-      <NavigationHint darkMode={darkMode} />
+    return (
+      <div className="flex-1 flex flex-col relative overflow-hidden font-serif">
+        <CopyButton lines={lines} activeLine={activeLine} darkMode={darkMode} />
+        <NavigationHint darkMode={darkMode} />
 
-      <div
-        ref={linesContainerRef}
-        className={`flex-1 px-4 md:px-6 pt-6 writing-container flex flex-col justify-end ${
-          darkMode ? "bg-gray-900 text-gray-200" : "bg-[#fcfcfa] text-gray-800"
-        }`}
-        style={{
-          fontSize: `${stackFontSize}px`,
-          lineHeight: isFullscreen ? "1.3" : "1.4",
-          overflow: "hidden",
-        }}
-        aria-live="polite"
-      >
-        <LineStack
-          visibleLines={visibleLines.map((line, index) => ({ line, index: lines.indexOf(line) }))}
-          darkMode={darkMode}
-          stackFontSize={stackFontSize}
-          mode={mode}
-          selectedLineIndex={selectedLineIndex}
-          isFullscreen={isFullscreen}
-        />
+        <div className="flex-1 flex flex-col h-full overflow-hidden">
+          <div
+            ref={linesContainerRef}
+            className={`flex-1 overflow-hidden px-4 md:px-6 pt-6 writing-container flex flex-col justify-end ${
+              darkMode ? "bg-gray-900 text-gray-200" : "bg-[#fcfcfa] text-gray-800"
+            }`}
+            style={{
+              fontSize: `${stackFontSize}px`,
+              lineHeight: isFullscreen ? "1.3" : "1.4",
+            }}
+            aria-live="polite"
+          >
+            <LineStack
+              visibleLines={visibleLines.map((line, index) => ({ line, index: lines.indexOf(line) }))}
+              darkMode={darkMode}
+              stackFontSize={stackFontSize}
+              mode={mode}
+              selectedLineIndex={selectedLineIndex}
+              isFullscreen={isFullscreen}
+            />
+          </div>
+
+          {mode === "typing" && (
+            <ActiveLine
+              activeLine={activeLine}
+              darkMode={darkMode}
+              fontSize={fontSize}
+              showCursor={showCursor}
+              maxCharsPerLine={maxCharsPerLine}
+              hiddenInputRef={hiddenInputRef} // Pass the ref
+              isAndroid={typeof navigator !== "undefined" && navigator.userAgent.includes("Android")}
+              isFullscreen={isFullscreen}
+            />
+          )}
+        </div>
       </div>
-
-      {mode === "typing" && (
-        <ActiveLine
-          activeLine={activeLine}
-          darkMode={darkMode}
-          fontSize={fontSize}
-          showCursor={showCursor}
-          maxCharsPerLine={maxCharsPerLine}
-          hiddenInputRef={hiddenInputRef} // Pass the ref
-          isAndroid={typeof navigator !== "undefined" && navigator.userAgent.includes("Android")}
-          isFullscreen={isFullscreen}
-        />
-      )}
-    </div>
-  )
-}
+    )
+  }

--- a/components/writing-area/ActiveLine.tsx
+++ b/components/writing-area/ActiveLine.tsx
@@ -48,7 +48,7 @@ export function ActiveLine({
 }: ActiveLineProps) {
   useAutoResizeTextarea(hiddenInputRef, activeLine)
 
-  const fixedActiveLineClass = `flex-shrink-0 font-serif border-t z-10 active-line relative ${
+  const fixedActiveLineClass = `flex-shrink-0 sticky bottom-0 font-serif border-t z-10 active-line relative ${
     darkMode
       ? "bg-gray-800 border-gray-700 shadow-[0_-8px_16px_rgba(0,0,0,0.3)]"
       : "bg-[#f3efe9] border-[#e0dcd3] shadow-[0_-8px_16px_rgba(0,0,0,0.1)]"


### PR DESCRIPTION
## Summary
- keep line stack and active line in a flex column container with full height and hidden overflow
- apply overflow-hidden to line stack and make active line sticky

## Testing
- `npm test` *(fails: Request is not defined, module not found, expectation mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_689246567650832288ad3a75ad2c03f9