### PR TITLE
Refactor visible lines to include ids

### DIFF
--- a/components/writing-area/LineStack.tsx
+++ b/components/writing-area/LineStack.tsx
@@ -1,7 +1,7 @@
 import { memo } from "react"
 
 interface LineStackProps {
-  visibleLines: { line: string; index: number }[]
+  visibleLines: { id: number; text: string }[]
   darkMode: boolean
   stackFontSize: number
   mode: "typing" | "navigating"
@@ -38,13 +38,13 @@ export const LineStack = memo(function LineStack({
         margin: "0",
       }}
     >
-      {visibleLines.map(({ line, index }) => {
-        const isSelected = index === selectedLineIndex
+      {visibleLines.map(({ id, text }, i) => {
+        const isSelected = id === selectedLineIndex
         const selectedClass = isSelected
           ? `${darkMode ? "bg-gray-700" : "bg-amber-100"} rounded-md p-1 -m-1 ring-2 ${darkMode ? "ring-blue-500" : "ring-amber-400"}`
           : ""
 
-        const isLastActive = index === visibleLines.length - 1 && mode === "typing"
+        const isLastActive = i === visibleLines.length - 1 && mode === "typing"
         const lastActiveStyle = isLastActive
           ? {
               fontWeight: 500,
@@ -55,12 +55,12 @@ export const LineStack = memo(function LineStack({
 
         return (
           <div
-            key={index}
+            key={id}
             className={`whitespace-pre-wrap break-words mb-2 font-serif ${selectedClass}`}
-            data-line-index={index}
+            data-line-index={id}
             style={{ margin: "0", padding: "0", ...lastActiveStyle }}
           >
-            {line || " "} {/* Render a space for empty lines to maintain height */}
+            {text || " "} {/* Render a space for empty lines to maintain height */}
           </div>
         )
       })}

--- a/hooks/useVisibleLines.ts
+++ b/hooks/useVisibleLines.ts
@@ -11,15 +11,20 @@ import { useState, useEffect, useMemo } from "react"
  * @param mode - Aktueller Modus (typing oder navigating)
  * @param selectedLineIndex - Index der ausgewählten Zeile im Navigationsmodus
  * @param isFullscreen - Ob der Vollbildmodus aktiv ist
- * @returns Die aktuell sichtbaren Zeilen mit ihren globalen Indizes
+ * @returns Die aktuell sichtbaren Zeilen mit IDs
  */
+export interface VisibleLine {
+  id: number
+  text: string
+}
+
 export function useVisibleLines(
   lines: string[],
   maxVisibleLines: number,
   mode: "typing" | "navigating",
   selectedLineIndex: number | null,
   isFullscreen = false,
-) {
+): VisibleLine[] {
   const [isAndroid, setIsAndroid] = useState(false)
   const [useVirtualization, setUseVirtualization] = useState(false)
 
@@ -64,7 +69,7 @@ export function useVisibleLines(
       }
     }
 
-    return lines.slice(start, end + 1).map((line, i) => ({ line, index: start + i }))
+    return lines.slice(start, end + 1).map((text, i) => ({ id: start + i, text }))
   }, [lines, maxVisibleLines, mode, selectedLineIndex, useVirtualization, isAndroid, isFullscreen])
 
   return calculateVisibleLines


### PR DESCRIPTION
## Summary
- use new `{id, text}` shape for visibleLines
- return id/text pairs from `useVisibleLines`

## Testing
- `npm test` *(fails: Request is not defined, missing module '../../utils/line-break-utils', TypewriterStore expectation)*

------
https://chatgpt.com/codex/tasks/task_e_68935f8353908322b4e12ac69be4d38c