### PR TITLE
feat: observe input height changes

### DIFF
--- a/hooks/useMaxVisibleLines.ts
+++ b/hooks/useMaxVisibleLines.ts
@@ -14,16 +14,25 @@ export function useMaxVisibleLines(
 
   useLayoutEffect(() => {
     const HEADER_HEIGHT = 40
-
-    const resize = () => {
+    const calculate = () => {
       const vh = window.innerHeight
       const inputH = inputRef.current?.offsetHeight ?? 0
       setMaxVisible(Math.floor((vh - HEADER_HEIGHT - inputH) / lineHeight))
     }
 
-    resize()
-    window.addEventListener("resize", resize)
-    return () => window.removeEventListener("resize", resize)
+    calculate()
+
+    const element = inputRef.current
+    const observer = new ResizeObserver(() => calculate())
+    if (element) observer.observe(element)
+
+    window.addEventListener("resize", calculate)
+
+    return () => {
+      window.removeEventListener("resize", calculate)
+      if (element) observer.unobserve(element)
+      observer.disconnect()
+    }
   }, [inputRef, lineHeight])
 
   return maxVisible


### PR DESCRIPTION
## Summary
- adjust useMaxVisibleLines hook to recalculate on input height changes using ResizeObserver

## Testing
- `npm test` (fails: Cannot find module '../../utils/line-break-utils')
- `npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68935f9074f883228524906a7edb08e0