### PR TITLE
fix: resolve syntax issues in main page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,8 @@ export default function TypewriterPage() {
   const {
     lines,
     activeLine,
+    setActiveLine,
+    addLineToStack,
     maxCharsPerLine,
     statistics,
     lineBreakConfig,
@@ -44,6 +46,9 @@ export default function TypewriterPage() {
     stopFlowMode,
     updateFlowMode,
     saveSession,
+    handleKeyPress,
+    setContainerWidth,
+    setMaxVisibleLines,
   } = useTypewriterStore()
 
   const viewportRef = useRef<HTMLDivElement>(null)
@@ -73,6 +78,10 @@ export default function TypewriterPage() {
   const { focusInputSafely } = useAndroidKeyboard({
     inputRef: hiddenInputRef,
   })
+
+  const focusInput = useCallback(() => {
+    focusInputSafely()
+  }, [focusInputSafely])
 
   useResponsiveTypography({
     initialFontSize: fontSize,
@@ -123,7 +132,7 @@ export default function TypewriterPage() {
     if (mode === "typing" && selectedLineIndex === null) {
       focusInput()
     }
-  }, [isAndroid, focusInputSafely])
+  }, [mode, selectedLineIndex, focusInput])
 
   // Globale Tastatur-Listener
   useEffect(() => {
@@ -200,10 +209,6 @@ export default function TypewriterPage() {
   ])
 
   const openSettings = useCallback(() => setShowSettings(true), [])
-  const closeSettings = useCallback(() => {
-    setShowSettings(false)
-    focusInput()
-  }, [focusInput])
 
   // Effekt für Layout-Anpassungen
   useEffect(() => {
@@ -310,7 +315,7 @@ export default function TypewriterPage() {
           openSettings={openSettings}
           openFlowSettings={openFlowSettings}
         />
-      </header>
+      )}
 
       <main className="flex-1 flex flex-col p-4 md:p-6 lg:p-8 overflow-hidden">
         <section

--- a/components/control-bar.tsx
+++ b/components/control-bar.tsx
@@ -288,30 +288,6 @@ function ControlBar({
     </div>
   )
 
-        <Button
-          variant="outline"
-          size={buttonSize}
-          onClick={handleOpenFlowSettings}
-          className={buttonClass}
-          aria-label="Flow Mode"
-          title="Flow Mode"
-        >
-          <Rocket className="h-4 w-4" />
-        </Button>
-
-        <Button
-          variant="outline"
-          size={buttonSize}
-          onClick={handleOpenSettings}
-          className={buttonClass}
-          aria-label="Einstellungen"
-          title="Einstellungen"
-        >
-          <Settings className="h-4 w-4" />
-        </Button>
-      </div>
-    )
-  }
 
   // Standard-Layout
   return (

--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -90,6 +90,12 @@ export default function WritingArea({
   // Ref für die letzte Neuberechnung
   const lastRecalculation = useRef(Date.now())
 
+  const scrollToBottom = () => {
+    if (linesContainerRef.current) {
+      linesContainerRef.current.scrollTop = linesContainerRef.current.scrollHeight
+    }
+  }
+
   // Messe die Container-Höhe
   useEffect(() => {
     if (!linesContainerRef.current) return
@@ -102,12 +108,18 @@ export default function WritingArea({
       }
     }
 
+    updateHeight()
+    const observer = new ResizeObserver(updateHeight)
+    observer.observe(linesContainerRef.current)
+
+    return () => observer.disconnect()
+  }, [containerHeight, linesContainerRef])
+
   useEffect(() => {
     if (externalLinesContainerRef) {
       externalLinesContainerRef.current = linesContainerRef.current
     }
 
-    // Reduziere auf eine verzögerte Operation
     const timeoutId = setTimeout(scrollToBottom, 150)
     return () => clearTimeout(timeoutId)
   }, [lines.length, mode])
@@ -169,7 +181,6 @@ export default function WritingArea({
           activeLineRef={activeLineRef}
           isAndroid={typeof navigator !== "undefined" && navigator.userAgent.includes("Android")}
           isFullscreen={isFullscreen}
-          activeLineRef={activeLineRef}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- expose missing store actions in main page and wire up focus helper
- remove stray closing tag and unreachable markup
- restore writing area layout helpers

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: Expected ',' got 'if' in store/typewriter-store.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6893736c015483228d2dca89c8382b22