### PR TITLE
Import keyboard handling hook in WritingArea

### DIFF
--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -6,6 +6,7 @@ import type { LineBreakConfig, ParagraphRange, FormattedLine } from "@/types"
 
 import { useVisibleLines } from "@/hooks/useVisibleLines"
 import { useContainerDimensions } from "@/hooks/useContainerDimensions"
+import { useKeyboardHandling } from "@/hooks/useKeyboardHandling"
 import { CopyButton } from "./writing-area/CopyButton"
 import { NavigationHint } from "./writing-area/NavigationHint"
 import { LineStack } from "./writing-area/LineStack"


### PR DESCRIPTION
## Summary
- import keyboard handling hook in WritingArea
- ensure `handleChange` and `handleKeyDown` are still retrieved from the hook

## Testing
- `npm test` *(fails: MessagePort is not defined)*
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689383ddcd4483229bc32fcfd3af88b2