### PR TITLE
feat: define line type

### DIFF
--- a/__tests__/store/typewriter-store.test.ts
+++ b/__tests__/store/typewriter-store.test.ts
@@ -36,7 +36,7 @@ describe("TypewriterStore", () => {
     })
 
     expect(result.current.lines).toHaveLength(1)
-    expect(result.current.lines[0]).toBe("Test line")
+    expect(result.current.lines[0].text).toBe("Test line")
     expect(result.current.activeLine).toBe("")
   })
 

--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 import { useEffect, useState, useRef } from "react"
-import type { LineBreakConfig, ParagraphRange, FormattedLine } from "@/types"
+import type { LineBreakConfig, ParagraphRange, FormattedLine, Line } from "@/types"
 
 import { useVisibleLines } from "@/hooks/useVisibleLines"
 import { useContainerDimensions } from "@/hooks/useContainerDimensions"

--- a/hooks/useVisibleLines.ts
+++ b/hooks/useVisibleLines.ts
@@ -1,84 +1,44 @@
 "use client"
 
 import { useMemo } from "react"
+import type { Line, FormattedLine } from "@/types"
 
-/**
- * Hook zur Berechnung der sichtbaren Zeilen.
- *
- * - Im Tippmodus werden einfach die letzten `maxVisibleLines` Zeilen zurückgegeben.
- * - Im Navigationsmodus wird ein Fenster von `maxVisibleLines` Zeilen um den
- *   `selectedLineIndex` zentriert zurückgegeben.
- */
 export interface VisibleLine {
-  id: number
-  text: string
+  line: FormattedLine
+  index: number
+  key: string
 }
 
 export function useVisibleLines(
-  allLines: Line[],
+  lines: Line[],
   maxVisibleLines: number,
   mode: "typing" | "navigating",
   selectedLineIndex: number | null,
-) {
-  const [isAndroid, setIsAndroid] = useState(false)
-  const [useVirtualization, setUseVirtualization] = useState(false)
-
-  useEffect(() => {
-    const isAndroidDevice = navigator.userAgent.includes("Android")
-    setIsAndroid(isAndroidDevice)
-    const threshold = isFullscreen ? 200 : isAndroidDevice ? 100 : 80
-    setUseVirtualization(lines.length > threshold)
-  }, [lines.length, isFullscreen])
-
-  const calculateVisibleLines = useMemo(() => {
+  _isFullscreen: boolean,
+): VisibleLine[] {
+  return useMemo(() => {
     if (lines.length === 0) return []
 
-    let result
-    if (!useVirtualization || lines.length <= maxVisibleLines) {
-      if (mode === "typing") {
-        if (lines.length <= maxVisibleLines) {
-          result = lines
-        } else {
-          const start = Math.max(0, lines.length - maxVisibleLines)
-          result = lines.slice(start)
-        }
-      } else {
-        const visibleCount = Math.min(maxVisibleLines, lines.length)
-        const contextLines = Math.floor(visibleCount / 2)
-        const start = Math.max(0, (selectedLineIndex ?? 0) - contextLines)
-        const end = Math.min(lines.length - 1, start + visibleCount - 1)
-        result = lines
-          .slice(start, end + 1)
-          .map((line, idx) => ({ line, index: start + idx }))
-      }
-    } else {
-      if (mode === "navigating" && selectedLineIndex !== null) {
-        const contextLines = isFullscreen ? 20 : isAndroid ? 15 : 10
-        const visibleStart = Math.max(0, selectedLineIndex - contextLines)
-        const visibleEnd = Math.min(lines.length - 1, selectedLineIndex + contextLines)
-        result = lines
-          .slice(visibleStart, visibleEnd + 1)
-          .map((line, idx) => ({ line, index: visibleStart + idx }))
-      } else {
-        const visibleCount = Math.min(maxVisibleLines, lines.length)
-        if (lines.length <= visibleCount) {
-          result = lines.map((line, index) => ({ line, index }))
-        } else {
-          const visibleStart = Math.max(0, lines.length - visibleCount)
-          result = lines
-            .slice(visibleStart)
-            .map((line, idx) => ({ line, index: visibleStart + idx }))
-        }
-      }
+    const visibleCount = Math.min(maxVisibleLines, lines.length)
+
+    const buildResult = (start: number) =>
+      lines.slice(start, start + visibleCount).map((line, idx) => ({
+        line: { text: line.text },
+        index: start + idx,
+        key: String(line.id),
+      }))
+
+    if (mode === "typing") {
+      const start = Math.max(0, lines.length - visibleCount)
+      return buildResult(start)
     }
 
-    const half = Math.floor(maxVisibleLines / 2)
-    const maxStart = Math.max(0, lines.length - maxVisibleLines)
-    let start = selectedLineIndex - half
-    if (start < 0) start = 0
-    if (start > maxStart) start = maxStart
-    const end = start + maxVisibleLines
-
-    return lines.slice(start, end)
+    const context = Math.floor(visibleCount / 2)
+    const center = selectedLineIndex ?? 0
+    let start = Math.max(0, center - context)
+    if (start + visibleCount > lines.length) {
+      start = Math.max(0, lines.length - visibleCount)
+    }
+    return buildResult(start)
   }, [lines, maxVisibleLines, mode, selectedLineIndex])
 }

--- a/store/typewriter-store.ts
+++ b/store/typewriter-store.ts
@@ -22,12 +22,14 @@ const initialState: Omit<
   fontSize: 24,
   stackFontSize: 18,
   darkMode: false,
+  paragraphRanges: [],
+  inParagraph: false,
+  currentParagraphStart: 0,
   mode: "typing",
   selectedLineIndex: null,
   offset: 0,
   maxVisibleLines: 0,
   flowMode: false, // Neuer Zustand für den Flow Mode
-  offset: 0,
 }
 
 let nextLineId = 1
@@ -408,7 +410,7 @@ export const useTypewriterStore = create<TypewriterState & TypewriterActions>()(
         if (state) {
           if (state.lines && state.lines.length > 0) {
             if (typeof state.lines[0] === "string") {
-              state.lines = (state.lines as string[]).map((text) => ({
+              state.lines = (state.lines as unknown as string[]).map((text) => ({
                 id: nextLineId++,
                 text,
               }))

--- a/types.ts
+++ b/types.ts
@@ -29,6 +29,16 @@ export interface ParagraphRange {
 }
 
 /**
+ * Repräsentiert eine Zeile im Textstack
+ */
+export interface Line {
+  /** Eindeutige ID der Zeile */
+  id: number
+  /** Der Textinhalt der Zeile */
+  text: string
+}
+
+/**
  * Repräsentiert eine einfache Zeile Text
  */
 export interface FormattedLine {
@@ -112,8 +122,6 @@ export interface TypewriterState {
   containerWidth: number
   /** Ob der Flow Mode (kein Löschen) aktiviert ist */
   flowMode: boolean
-  /** Offset für die Berechnung der sichtbaren Zeilen */
-  offset: number
 }
 
 /**


### PR DESCRIPTION
## Summary
- add Line interface and link state to typed lines
- update hooks and components to use Line[]
- adjust store initialization and migration for line objects

## Testing
- `npx tsc --noEmit` *(fails: Cannot find name 'cy', etc.)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689383e14ea883228c47bb2f86759e00