### PR TITLE
feat: isolate line stack scrolling

### DIFF
--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -143,20 +143,18 @@ export default function WritingArea({
   const isAndroid = typeof navigator !== "undefined" && navigator.userAgent.includes("Android")
 
   return (
-    <div className="flex-1 flex flex-col relative overflow-x-hidden overflow-y-auto font-serif">
+    <div className="flex-1 flex flex-col relative overflow-hidden font-serif">
       <CopyButton lines={lines} activeLine={activeLine} darkMode={darkMode} />
       <NavigationHint darkMode={darkMode} />
 
       <div
         ref={linesContainerRef}
-        className={`flex-1 px-4 md:px-6 pt-6 writing-container flex flex-col justify-start ${
+        className={`flex-1 overflow-y-auto overflow-x-hidden px-4 md:px-6 pt-6 writing-container flex flex-col justify-start ${
           darkMode ? "bg-gray-900 text-gray-200" : "bg-[#fcfcfa] text-gray-800"
         }`}
         style={{
           fontSize: `${stackFontSize}px`,
           lineHeight: isFullscreen ? "1.3" : "1.4",
-          overflowY: "auto",
-          overflowX: "hidden",
         }}
         aria-live="polite"
       >


### PR DESCRIPTION
## Summary
- Prevent outer writing area from scrolling and let LineStack handle its own overflow
- Preserve sticky positioning for the active line

## Testing
- `npm test` *(fails: MessagePort is not defined)*
- `npm run lint` *(fails: 'MarkdownIndicator' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68939a57e7a48322a9f3f456954d666a