### PR TITLE
Simplify LineStack rendering

### DIFF
--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 import { useEffect, useState, useRef } from "react"
-import type { LineBreakConfig, ParagraphRange, FormattedLine, Line } from "@/types"
+import type { LineBreakConfig, Line } from "@/types"
 
 import { useVisibleLines } from "@/hooks/useVisibleLines"
 import { useContainerDimensions } from "@/hooks/useContainerDimensions"
@@ -65,7 +65,6 @@ export default function WritingArea({
   const {
     linesContainerRef: internalLinesContainerRef,
     activeLineRef,
-    lineRefs,
     maxVisibleLines,
   } = useContainerDimensions(stackFontSize)
 
@@ -162,12 +161,8 @@ export default function WritingArea({
       >
         <LineStack
           visibleLines={visibleLines}
-          darkMode={darkMode}
-          stackFontSize={stackFontSize}
           mode={mode}
-          selectedLineIndex={selectedLineIndex}
           isFullscreen={isFullscreen}
-          linesContainerRef={linesContainerRef}
         />
       </div>
 

--- a/components/writing-area/LineStack.tsx
+++ b/components/writing-area/LineStack.tsx
@@ -1,31 +1,17 @@
-import type React from "react"
-import type { FormattedLine } from "@/types"
 import { memo } from "react"
 
 interface LineStackProps {
-  visibleLines: { line: FormattedLine; index: number; key: string }[]
-  lineRefs: React.MutableRefObject<(HTMLDivElement | null)[]>
-  darkMode: boolean
-  stackFontSize: number
+  visibleLines: { line: { text: string }; index: number; key: string }[]
   mode: "typing" | "navigating"
-  selectedLineIndex: number | null
   isFullscreen?: boolean
-  linesContainerRef?: React.RefObject<HTMLDivElement>
 }
 
 export const LineStack = memo(function LineStack({
   visibleLines,
-  darkMode,
-  stackFontSize,
   mode,
-  selectedLineIndex,
   isFullscreen = false,
-  linesContainerRef,
 }: LineStackProps) {
   const isAndroid = typeof navigator !== "undefined" && navigator.userAgent.includes("Android")
-
-  // Reference the container ref to avoid unused variable warnings
-  void linesContainerRef
 
   return (
     <div
@@ -47,82 +33,11 @@ export const LineStack = memo(function LineStack({
         marginBottom: "0",
       }}
     >
-      {visibleLines.map(({ line, index, key }) => {
-        const props = renderFormattedLine(line, index, lineRefs) as any
-        const { as = "div", ...restProps } = props
-
-        // Verwende den generierten key, wenn vorhanden, sonst den Standard-key
-        const elementKey = key || props.key
-
-        // Prüfe, ob dies die zuletzt aktive Zeile ist (direkt über der aktuellen Schreibzeile)
-        const isLastActive = index === visibleLines.length - 1 && mode === "typing"
-        const lastActiveStyle = isLastActive
-          ? {
-              fontWeight: 500,
-              backgroundColor: darkMode ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.02)",
-              borderRadius: "2px",
-            }
-          : {}
-
-        // Dynamisch das richtige Element basierend auf 'as' erstellen
-        const ElementType = as as React.ElementType
-
-        if (as === "hr") {
-          return <hr key={elementKey} className={props.className} data-line-index={index} style={{ margin: "0" }} />
-        }
-
-        if (ElementType === "div" && Array.isArray(props.children)) {
-          // Für Listen und Dialog mit mehreren Kindern
-          return (
-            <div
-              key={elementKey}
-              ref={(el: HTMLElement | null) => {
-                if (typeof props.ref === "function") {
-                  ;(props.ref as (instance: HTMLElement | null) => void)(el)
-                } else if (props.ref && "current" in props.ref) {
-                  ;(props.ref as React.MutableRefObject<HTMLElement | null>).current =
-                    el
-                }
-              }}
-              className={props.className}
-              data-line-index={index}
-              // Kein Abstand für maximale Platznutzung
-              style={{ margin: "0", padding: "0", ...lastActiveStyle }}
-            >
-              {/* Füge den Markdown-Indikator hinzu */}
-              <MarkdownIndicator type={line.type} darkMode={darkMode} />
-              {(props.children as any[]).map((child: any, i: number) => {
-                if (typeof child === "string") return child
-                const ChildType = child.type as React.ElementType
-                return <ChildType key={i} {...(child.props as any)} />
-              })}
-            </div>
-          )
-        }
-
-        // Und auch für einfache Elemente
-        const Element = ElementType as React.ElementType
-        return (
-          <Element
-            key={elementKey}
-            ref={(el: HTMLElement | null) => {
-              if (typeof props.ref === "function") {
-                ;(props.ref as (instance: HTMLElement | null) => void)(el)
-              } else if (props.ref && "current" in props.ref) {
-                ;(props.ref as React.MutableRefObject<HTMLElement | null>).current =
-                  el
-              }
-            }}
-            className={props.className}
-            data-line-index={index}
-            style={{ margin: "0", padding: "0", ...lastActiveStyle }}
-          >
-            {/* Füge den Markdown-Indikator hinzu */}
-            <MarkdownIndicator type={line.type} darkMode={darkMode} />
-            {props.children as React.ReactNode}
-          </Element>
-        )
-      })}
+      {visibleLines.map(({ line, index, key }) => (
+        <div key={key} data-line-index={index} style={{ margin: "0", padding: "0" }}>
+          {line.text}
+        </div>
+      ))}
     </div>
   )
 })


### PR DESCRIPTION
## Summary
- streamline LineStack to render visible lines as plain `<div>` elements
- adjust WritingArea to pass simplified props

## Testing
- `npm test` *(fails: MessagePort is not defined in undici)*

------
https://chatgpt.com/codex/tasks/task_e_68939a5505d08322a1d8b4a6719c0726