### PR TITLE
fix: remove scroll overflow from writing area

### DIFF
--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -148,7 +148,7 @@ export default function WritingArea({
 
       <div
         ref={linesContainerRef}
-        className={`flex-1 overflow-y-auto overflow-x-hidden px-4 md:px-6 pt-6 writing-container flex flex-col justify-start ${
+        className={`flex-1 overflow-hidden overflow-x-hidden px-4 md:px-6 pt-6 writing-container flex flex-col justify-start ${
           darkMode ? "bg-gray-900 text-gray-200" : "bg-[#fcfcfa] text-gray-800"
         }`}
         style={{

--- a/components/writing-area/LineStack.tsx
+++ b/components/writing-area/LineStack.tsx
@@ -19,8 +19,7 @@ export const LineStack = memo(function LineStack({
     <div
       className="line-stack"
       style={{
-        overflowY: "auto",
-        overflowX: "hidden",
+        overflow: "hidden",
         display: "flex",
         flexDirection: "column",
         // Beginne im Tippmodus oben links, damit die erste Zeile an der Oberkante startet


### PR DESCRIPTION
## Summary
- replace overflow-y-auto with overflow-hidden in writing area containers
- prevent LineStack from using overflowY: auto

## Testing
- `npx jest` *(fails: Cannot find module '@testing-library/jest-dom')*
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68949ede147083229ba6d359baeca207