### PR TITLE
Remove duplicate offline indicator

### DIFF
--- a/__tests__/app/android-input.test.tsx
+++ b/__tests__/app/android-input.test.tsx
@@ -3,6 +3,12 @@ import TypewriterPage from "@/app/page"
 import { useTypewriterStore } from "@/store/typewriter-store"
 
 describe("Android key event sequence", () => {
+  beforeAll(() => {
+    HTMLCanvasElement.prototype.getContext = () => ({
+      measureText: () => ({ width: 10 }),
+    }) as any
+  })
+
   beforeEach(() => {
     useTypewriterStore.getState().resetSession()
     jest.useFakeTimers()
@@ -19,6 +25,7 @@ describe("Android key event sequence", () => {
       fireEvent.keyDown(document.body, { key: "a" })
       jest.advanceTimersByTime(20)
       fireEvent.keyDown(document.body, { key: "a" })
+      fireEvent.keyUp(document.body, { key: "a" })
     })
 
     expect(useTypewriterStore.getState().activeLine).toBe("a")
@@ -29,8 +36,10 @@ describe("Android key event sequence", () => {
 
     act(() => {
       fireEvent.keyDown(document.body, { key: "a" })
+      fireEvent.keyUp(document.body, { key: "a" })
       jest.advanceTimersByTime(60)
       fireEvent.keyDown(document.body, { key: "a" })
+      fireEvent.keyUp(document.body, { key: "a" })
     })
 
     expect(useTypewriterStore.getState().activeLine).toBe("aa")

--- a/__tests__/app/offline-indicator.test.tsx
+++ b/__tests__/app/offline-indicator.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react"
+import TypewriterPage from "@/app/page"
+import { useTypewriterStore } from "@/store/typewriter-store"
+
+describe("OfflineIndicator", () => {
+  const originalOnLine = navigator.onLine
+
+  beforeEach(() => {
+    useTypewriterStore.getState().resetSession()
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: originalOnLine,
+    })
+  })
+
+  it("renders a single offline indicator in light mode", async () => {
+    useTypewriterStore.setState({ darkMode: false })
+    render(<TypewriterPage />)
+    const indicators = await screen.findAllByText("Offline-Modus")
+    expect(indicators).toHaveLength(1)
+  })
+
+  it("renders a single offline indicator in dark mode", async () => {
+    useTypewriterStore.setState({ darkMode: true })
+    render(<TypewriterPage />)
+    const indicators = await screen.findAllByText("Offline-Modus")
+    expect(indicators).toHaveLength(1)
+  })
+})

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -346,9 +346,6 @@ export default function TypewriterPage() {
       )}
       <SettingsModal isOpen={showSettings} onClose={closeSettings} darkMode={darkMode} />
       <FlowSettingsModal isOpen={showFlowSettings} onClose={closeFlowSettings} darkMode={darkMode} />
-
-      {/* Offline-Indikator hinzufügen */}
-      <OfflineIndicator darkMode={darkMode} />
     </div>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.54.2",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
         "@types/jest": "^29",
@@ -3462,7 +3463,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3483,7 +3483,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3497,7 +3496,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3507,8 +3505,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/dom/node_modules/pretty-format": {
       "version": "27.5.1",
@@ -3516,7 +3513,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3531,8 +3527,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.6.4",
@@ -3588,8 +3583,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4571,7 +4565,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6426,7 +6419,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^29",


### PR DESCRIPTION
## Summary
- remove extra `<OfflineIndicator />` so only one instance exists
- add tests ensuring offline indicator renders once in both themes
- install missing DOM testing utilities and stabilize Android input test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894c31b9130832294523a13b49cd954