### PR TITLE
refactor: remove scroll effect and slice lines by offset

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,6 +37,7 @@ export default function TypewriterPage() {
     inParagraph,
     mode,
     selectedLineIndex,
+    offset,
     adjustOffset,
     navigateForward,
     navigateBackward,
@@ -306,7 +307,7 @@ export default function TypewriterPage() {
           stackFontSize={stackFontSize}
           darkMode={darkMode}
           mode={mode}
-          selectedLineIndex={selectedLineIndex}
+          offset={offset}
           isFullscreen={isFullscreen}
           linesContainerRef={linesContainerRef}
         />

--- a/hooks/useVisibleLines.ts
+++ b/hooks/useVisibleLines.ts
@@ -13,9 +13,7 @@ export interface VisibleLine {
 export function useVisibleLines(
   lines: Line[],
   maxVisibleLines: number,
-  mode: "typing" | "navigating",
-  selectedLineIndex: number | null,
-  _isFullscreen: boolean,
+  offset: number,
 ): VisibleLine[] {
   return useMemo(() => {
     if (lines.length === 0) return []
@@ -59,24 +57,11 @@ export function useVisibleLines(
       return { text: content, type, level, order }
     }
 
-    const buildResult = (start: number) =>
-      lines.slice(start, start + visibleCount).map((line, idx) => ({
-        line: parseLine(line.text),
-        index: start + idx,
-        key: String(line.id),
-      }))
-
-    if (mode === "typing") {
-      const start = Math.max(0, lines.length - visibleCount)
-      return buildResult(start)
-    }
-
-    const context = Math.floor(visibleCount / 2)
-    const center = selectedLineIndex ?? 0
-    let start = Math.max(0, center - context)
-    if (start + visibleCount > lines.length) {
-      start = Math.max(0, lines.length - visibleCount)
-    }
-    return buildResult(start)
-  }, [lines, maxVisibleLines, mode, selectedLineIndex])
+    const start = Math.max(0, lines.length - visibleCount - offset)
+    return lines.slice(start, start + visibleCount).map((line, idx) => ({
+      line: parseLine(line.text),
+      index: start + idx,
+      key: String(line.id),
+    }))
+  }, [lines, maxVisibleLines, offset])
 }


### PR DESCRIPTION
## Summary
- eliminate scrollIntoView logic from writing area and combine refs
- drive rendering from offset-based visible slice via updated hook

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook useEffect has a missing dependency warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6895f5c1cb0c8322b0f17832e6fba55e