### PR TITLE
refactor: remove overflow-auto usages

### DIFF
--- a/components/control-bar.tsx
+++ b/components/control-bar.tsx
@@ -265,7 +265,11 @@ function ControlBar({
   ]
 
   const renderButtonGroup = (buttons: any[], showLabels = true) => (
-    <div className={`flex ${isVeryNarrowScreen ? "gap-1" : "gap-2"}`}>
+    <div
+      className={`flex ${
+        isVeryNarrowScreen ? "flex-wrap justify-center gap-1" : "gap-2"
+      }`}
+    >
       {buttons.map((btn, index) => (
         <Button
           key={index}
@@ -314,7 +318,7 @@ function ControlBar({
           <div className="flex justify-center gap-2">
             {renderButtonGroup(primaryButtons, false)}
           </div>
-          <div className="flex justify-center gap-2 overflow-x-auto pb-1">
+          <div className="flex justify-center gap-2 pb-1">
             {renderButtonGroup(secondaryButtons, false)}
           </div>
         </div>

--- a/components/fullscreen-settings.tsx
+++ b/components/fullscreen-settings.tsx
@@ -32,7 +32,7 @@ export default function FullscreenSettings({ isOpen, onClose }: FullscreenSettin
   settingsContainer.style.zIndex = "999999"
   settingsContainer.style.backgroundColor = darkMode ? "#111827" : "#ffffff"
   settingsContainer.style.color = darkMode ? "#f3f4f6" : "#1f2937"
-  settingsContainer.style.overflow = "auto"
+    settingsContainer.style.overflow = "hidden"
 
   // Füge das Element zum body hinzu
   document.body.appendChild(settingsContainer)
@@ -77,8 +77,9 @@ export default function FullscreenSettings({ isOpen, onClose }: FullscreenSettin
 
   // Content-Bereich
   const content = document.createElement("div")
-  content.className = "p-6 space-y-8 overflow-y-auto"
-  content.style.height = "calc(100vh - 70px)"
+    content.className = "p-6 space-y-8"
+    content.style.height = "calc(100vh - 70px)"
+    content.style.overflowY = "hidden"
 
   // Füge den Inhalt hinzu (vereinfacht)
   content.innerHTML = `

--- a/components/settings-modal.tsx
+++ b/components/settings-modal.tsx
@@ -79,7 +79,7 @@ export default function SettingsModal({ isOpen, onClose, darkMode }: SettingsMod
 
       {/* Content */}
       <div
-        className="p-6 space-y-8 overflow-auto"
+        className="p-6 space-y-8 overflow-hidden"
         style={{
           height: "calc(100vh - 70px)",
           color: darkMode ? "#f9fafb" : "#111827",

--- a/components/settings-panel.tsx
+++ b/components/settings-panel.tsx
@@ -52,7 +52,7 @@ export default function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
     modalRoot.style.height = "100%"
     modalRoot.style.zIndex = "2147483647" // Höchstmöglicher z-index
     modalRoot.style.backgroundColor = darkMode ? "#111827" : "#ffffff"
-    modalRoot.style.overflow = "auto"
+    modalRoot.style.overflow = "hidden"
 
     // Verhindere Scrolling im Hintergrund
     const originalStyle = window.getComputedStyle(document.body).overflow
@@ -134,7 +134,7 @@ export default function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
     const content = document.createElement("div")
     content.className = "p-6 space-y-8"
     content.style.height = "calc(100vh - 70px)"
-    content.style.overflow = "auto"
+    content.style.overflow = "hidden"
     content.style.color = darkMode ? "#f9fafb" : "#111827"
 
     // Schriftgröße für aktive Zeile

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -60,10 +60,10 @@ const CommandList = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.List
     ref={ref}
-    className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
-    {...props}
-  />
-))
+      className={cn("max-h-[300px] overflow-hidden", className)}
+      {...props}
+    />
+  ))
 
 CommandList.displayName = CommandPrimitive.List.displayName
 

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -423,7 +423,7 @@ const SidebarContent = React.forwardRef<
       ref={ref}
       data-sidebar="content"
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-hidden group-data-[collapsible=icon]:overflow-hidden",
         className
       )}
       {...props}

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -6,7 +6,7 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
+    <div className="relative w-full overflow-hidden">
     <table
       ref={ref}
       className={cn("w-full caption-bottom text-sm", className)}

--- a/styles/android-fixes.css
+++ b/styles/android-fixes.css
@@ -11,7 +11,7 @@
   right: 0;
   bottom: 0;
   overflow-x: hidden;
-  overflow-y: auto;
+  overflow-y: hidden;
   -webkit-tap-highlight-color: transparent; /* Entfernt den blauen Highlight-Effekt bei Tap */
   touch-action: manipulation; /* Verbessert Touch-Reaktion */
 }
@@ -167,7 +167,7 @@
   bottom: 0;
   z-index: 9999;
   background-color: inherit;
-  overflow-y: auto;
+  overflow-y: hidden;
   -webkit-overflow-scrolling: touch;
 }
 
@@ -239,7 +239,7 @@ input[type="checkbox"] {
   width: 100%;
   height: 100%;
   background-color: white;
-  overflow-y: auto;
+  overflow-y: hidden;
   -webkit-overflow-scrolling: touch;
 }
 


### PR DESCRIPTION
## Summary
- hide overflow in Android fixes, modals, table, sidebar, and command list to prevent scrollbars
- restructure ControlBar to wrap buttons instead of using overflow scrolling
- confirmed LineStack and ancestors only use overflow-hidden

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint must be installed: npm install --save-dev eslint)*

------
https://chatgpt.com/codex/tasks/task_e_6895f5caea9083228232f9cd026c9430