### PR TITLE
Use hook for max visible lines and expose line-height variable

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState, useCallback } from "react"
+import { useEffect, useRef, useState, useCallback, CSSProperties } from "react"
 import { useTypewriterStore } from "@/store/typewriter-store"
 import WritingArea from "@/components/writing-area"
 import ControlBar from "@/components/control-bar"
@@ -10,6 +10,7 @@ import { ActiveLine } from "@/components/writing-area/ActiveLine"
 import NavigationIndicator from "@/components/navigation-indicator"
 import { useAndroidKeyboard } from "@/hooks/useAndroidKeyboard"
 import { useResponsiveTypography } from "@/hooks/useResponsiveTypography"
+import { useMaxVisibleLines } from "@/hooks/useMaxVisibleLines"
 import OfflineIndicator from "@/components/offline-indicator"
 import SaveNotification from "@/components/save-notification"
 import SettingsModal from "@/components/settings-modal"
@@ -18,7 +19,6 @@ import FlowModeOverlay from "@/components/flow-mode-overlay"
 
 // Importiere die ApiKeyWarning-Komponente am Anfang der Datei
 import ApiKeyWarning from "@/components/api-key-warning"
-import { debounce } from "@/utils/debounce" // Korrekter Import
 
 export default function TypewriterPage() {
   const {
@@ -48,7 +48,6 @@ export default function TypewriterPage() {
     saveSession,
     handleKeyPress,
     setContainerWidth,
-    setMaxVisibleLines,
   } = useTypewriterStore()
 
   const viewportRef = useRef<HTMLDivElement>(null)
@@ -64,9 +63,6 @@ export default function TypewriterPage() {
   const [showCursor, setShowCursor] = useState(true)
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [isAndroid, setIsAndroid] = useState(false)
-  const [orientation, setOrientation] = useState<"portrait" | "landscape">(
-    typeof window !== "undefined" && window.innerWidth > window.innerHeight ? "landscape" : "portrait",
-  )
   const [showSettings, setShowSettings] = useState(false)
   const [showFlowSettings, setShowFlowSettings] = useState(false)
 
@@ -88,6 +84,8 @@ export default function TypewriterPage() {
     setFontSize: useTypewriterStore.getState().setFontSize,
     setStackFontSize: useTypewriterStore.getState().setStackFontSize,
   })
+
+  const lineHpx = useMaxVisibleLines(viewportRef, headerRef, activeLineRef)
 
   const showTemporaryNavigationHint = useCallback(() => {
     if (navigationHintTimerRef.current) {
@@ -209,51 +207,25 @@ export default function TypewriterPage() {
 
   const openSettings = useCallback(() => setShowSettings(true), [])
 
-  // Effekt für Layout-Anpassungen
+  // Aktualisiere die Breite des Textcontainers
   useEffect(() => {
-    const updateLayout = debounce(() => {
-      // Korrektes Ref für die Breitenberechnung verwenden
+    const updateWidth = () => {
       if (linesContainerRef.current) {
         setContainerWidth(linesContainerRef.current.clientWidth)
       }
+    }
+    updateWidth()
+    const observer = new ResizeObserver(updateWidth)
+    if (linesContainerRef.current) observer.observe(linesContainerRef.current)
+    return () => observer.disconnect()
+  }, [setContainerWidth])
 
-      const viewportHeight = viewportRef.current?.clientHeight ?? window.innerHeight
-      const inputHeight = activeLineRef.current?.offsetHeight ?? 0
-      const optionsHeight = headerRef.current?.offsetHeight ?? 0
-
-      let lineHeight = 0
-      if (linesContainerRef.current) {
-        const stackLine = (linesContainerRef.current.querySelector(
-          ".line-stack div",
-        ) as HTMLElement | null) ||
-          (linesContainerRef.current.querySelector(
-            ".line-stack",
-          ) as HTMLElement | null)
-        if (stackLine) {
-          lineHeight = parseFloat(getComputedStyle(stackLine).lineHeight)
-        }
-      }
-      if (lineHeight) {
-        const maxLines = Math.floor(
-          (viewportHeight - inputHeight - optionsHeight) / lineHeight,
-        )
-        setMaxVisibleLines(maxLines)
-      }
-
-      if (typeof window !== "undefined") {
-        setOrientation(window.innerWidth > window.innerHeight ? "landscape" : "portrait")
-      }
-    }, 150)
-
+  // Android-Erkennung
+  useEffect(() => {
     const isAndroidDevice = /Android/.test(navigator.userAgent)
     setIsAndroid(isAndroidDevice)
     if (isAndroidDevice) document.body.classList.add("android-typewriter")
-
-    window.addEventListener("resize", updateLayout)
-    updateLayout()
-
-    return () => window.removeEventListener("resize", updateLayout)
-  }, [setContainerWidth])
+  }, [])
 
   const toggleFullscreen = useCallback(() => {
     if (!document.fullscreenElement) {
@@ -309,10 +281,14 @@ export default function TypewriterPage() {
           selectedLineIndex={selectedLineIndex}
           isFullscreen={isFullscreen}
           linesContainerRef={linesContainerRef}
+          lineHpx={lineHpx}
         />
       </div>
 
-      <ActiveInput className="shrink-0 sticky bottom-0">
+      <ActiveInput
+        className="shrink-0 sticky bottom-0"
+        style={{ ["--lineHpx" as any]: `${lineHpx}px` } as CSSProperties }
+      >
       <ActiveLine
           activeLine={activeLine}
           darkMode={darkMode}

--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -25,6 +25,7 @@ interface WritingAreaProps {
   selectedLineIndex: number | null
   isFullscreen: boolean
   linesContainerRef?: React.RefObject<HTMLDivElement | null>
+  lineHpx?: number
 }
 
 /**
@@ -42,6 +43,7 @@ export default function WritingArea({
   selectedLineIndex,
   isFullscreen,
   linesContainerRef: externalLinesContainerRef,
+  lineHpx,
 }: WritingAreaProps) {
   // Verwende Hooks für Container-Dimensionen
   const { linesContainerRef: internalLinesContainerRef, maxVisibleLines } =
@@ -113,7 +115,7 @@ export default function WritingArea({
         <LineStack
           visibleLines={visibleLines}
           mode={mode}
-          isFullscreen={isFullscreen}
+          lineHpx={lineHpx}
         />
       </div>
     </div>

--- a/components/writing-area/ActiveLine.tsx
+++ b/components/writing-area/ActiveLine.tsx
@@ -15,12 +15,9 @@ interface ActiveLineProps {
   showCursor: boolean
   maxCharsPerLine: number
   hiddenInputRef: React.RefObject<HTMLTextAreaElement | null>
-  handleChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
-  handleKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void
   activeLineRef: React.RefObject<HTMLDivElement | null>
   isAndroid?: boolean
   isFullscreen?: boolean
-  activeLineRef?: React.RefObject<HTMLDivElement | null>
 }
 
 /**
@@ -104,6 +101,8 @@ export function ActiveLine({
       className={fixedActiveLineClass}
       onClick={() => hiddenInputRef.current?.focus()}
       style={{
+        fontSize: `${fontSize}px`,
+        lineHeight: "var(--lineHpx, 1.2em)",
         minHeight: `${fontSize * 1.5 + 24}px`,
         padding: "12px 1.25rem",
         height: "auto",
@@ -119,7 +118,7 @@ export function ActiveLine({
         {/* Visible text with cursor */}
         <div
           className={activeLineTextClass}
-          style={{ fontSize: `${fontSize}px`, lineHeight: "1.2" }}
+          style={{ fontSize: `${fontSize}px`, lineHeight: "var(--lineHpx, 1.2em)" }}
           aria-hidden="true"
         >
           {activeLine.slice(0, cursorPosition)}
@@ -148,7 +147,7 @@ export function ActiveLine({
           className="absolute inset-0 w-full h-full bg-transparent text-transparent caret-transparent outline-none resize-none overflow-hidden z-10"
           style={{
             fontSize: `${fontSize}px`,
-            lineHeight: "1.5",
+            lineHeight: "var(--lineHpx, 1.2em)",
             fontFamily: "inherit",
           }}
           rows={1}

--- a/components/writing-area/LineStack.tsx
+++ b/components/writing-area/LineStack.tsx
@@ -1,20 +1,16 @@
-import { memo } from "react"
-import { MarkdownIndicator } from "./MarkdownIndicator"
-import { renderFormattedLine } from "./renderFormattedLine"
+import { memo, CSSProperties } from "react"
 
 interface LineStackProps {
   visibleLines: { line: { text: string }; index: number; key: string }[]
   mode: "typing" | "navigating"
-  isFullscreen?: boolean
+  lineHpx?: number
 }
 
 export const LineStack = memo(function LineStack({
   visibleLines,
   mode,
-  isFullscreen = false,
+  lineHpx,
 }: LineStackProps) {
-  const isAndroid = typeof navigator !== "undefined" && navigator.userAgent.includes("Android")
-
   return (
     <div
       className="line-stack"
@@ -26,12 +22,13 @@ export const LineStack = memo(function LineStack({
         // und neue Zeilen darunter erscheinen
         justifyContent: mode === "navigating" ? "center" : "flex-start",
         maxHeight: "100%",
-        lineHeight: isFullscreen ? "1.2" : isAndroid ? "1.3" : "1.5",
+        lineHeight: "var(--lineHpx)",
         gap: "0",
         padding: "0",
         margin: "0",
         paddingBottom: "0",
         marginBottom: "0",
+        ...(lineHpx ? ({ ["--lineHpx" as any]: `${lineHpx}px` } as CSSProperties) : {}),
       }}
     >
       {visibleLines.map(({ line, index, key }) => (
@@ -42,3 +39,4 @@ export const LineStack = memo(function LineStack({
     </div>
   )
 })
+


### PR DESCRIPTION
## Summary
- Replace manual resize handler with `useMaxVisibleLines` to compute visible lines
- Provide `--lineHpx` CSS variable to `LineStack` and `ActiveInput`
- Adjust active line component to respect shared line height

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895f5d8aaa483229b49b60d7157e582