### PR TITLE
Use offset for navigation and exit mode on typing

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,6 +37,7 @@ export default function TypewriterPage() {
     inParagraph,
     mode,
     selectedLineIndex,
+    offset,
     adjustOffset,
     navigateForward,
     navigateBackward,
@@ -164,8 +165,8 @@ export default function TypewriterPage() {
       if (event.key.startsWith("Arrow")) {
         event.preventDefault()
         showTemporaryNavigationHint()
-        if (event.key === "ArrowUp") adjustOffset(-1)
-        if (event.key === "ArrowDown") adjustOffset(1)
+        if (event.key === "ArrowUp") adjustOffset(1)
+        if (event.key === "ArrowDown") adjustOffset(-1)
         if (event.key === "ArrowLeft") navigateBackward(10)
         if (event.key === "ArrowRight") navigateForward(10)
         return
@@ -176,12 +177,13 @@ export default function TypewriterPage() {
           event.preventDefault()
           resetNavigation()
           focusInput() // Fokus nach Beenden der Navigation wiederherstellen
+          return
         }
-        return
       }
 
       if (event.key.length === 1 || event.key === "Backspace" || event.key === "Enter") {
         event.preventDefault()
+        resetNavigation()
         handleKeyPress(event.key)
       }
     }
@@ -306,7 +308,7 @@ export default function TypewriterPage() {
           stackFontSize={stackFontSize}
           darkMode={darkMode}
           mode={mode}
-          selectedLineIndex={selectedLineIndex}
+          offset={offset}
           isFullscreen={isFullscreen}
           linesContainerRef={linesContainerRef}
         />

--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -22,7 +22,7 @@ interface WritingAreaProps {
   stackFontSize: number
   darkMode: boolean
   mode: "typing" | "navigating"
-  selectedLineIndex: number | null
+  offset: number
   isFullscreen: boolean
   linesContainerRef?: React.RefObject<HTMLDivElement | null>
 }
@@ -39,7 +39,7 @@ export default function WritingArea({
   stackFontSize,
   darkMode,
   mode,
-  selectedLineIndex,
+  offset,
   isFullscreen,
   linesContainerRef: externalLinesContainerRef,
 }: WritingAreaProps) {
@@ -55,7 +55,7 @@ export default function WritingArea({
     lines,
     maxVisibleLines,
     mode,
-    selectedLineIndex,
+    offset,
     isFullscreen,
   )
 
@@ -68,7 +68,7 @@ export default function WritingArea({
       const container = linesContainerRef.current
       if (!container) return
 
-      const activeIndex = selectedLineIndex ?? lines.length - 1
+      const activeIndex = Math.max(0, lines.length - 1 - offset)
       const activeLineElement = container.querySelector<HTMLElement>(
         `[data-line-index="${activeIndex}"]`,
       )
@@ -86,7 +86,7 @@ export default function WritingArea({
     }, 150)
 
     return () => clearTimeout(timeoutId)
-  }, [lines.length, mode, selectedLineIndex, externalLinesContainerRef, linesContainerRef])
+  }, [lines.length, mode, offset, externalLinesContainerRef, linesContainerRef])
 
   useEffect(() => {
     if (linesContainerRef.current) {

--- a/hooks/useVisibleLines.ts
+++ b/hooks/useVisibleLines.ts
@@ -14,7 +14,7 @@ export function useVisibleLines(
   lines: Line[],
   maxVisibleLines: number,
   mode: "typing" | "navigating",
-  selectedLineIndex: number | null,
+  offset: number,
   _isFullscreen: boolean,
 ): VisibleLine[] {
   return useMemo(() => {
@@ -71,12 +71,7 @@ export function useVisibleLines(
       return buildResult(start)
     }
 
-    const context = Math.floor(visibleCount / 2)
-    const center = selectedLineIndex ?? 0
-    let start = Math.max(0, center - context)
-    if (start + visibleCount > lines.length) {
-      start = Math.max(0, lines.length - visibleCount)
-    }
+    const start = Math.max(0, lines.length - visibleCount - offset)
     return buildResult(start)
-  }, [lines, maxVisibleLines, mode, selectedLineIndex])
+  }, [lines, maxVisibleLines, mode, offset])
 }


### PR DESCRIPTION
## Summary
- use offset to determine visible lines and scroll position
- swap arrow key offset direction and reset navigation when typing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895f5d9c234832284d4121850e0a55c