### PR TITLE
Use string IDs for lines

### DIFF
--- a/__tests__/store/typewriter-store.test.ts
+++ b/__tests__/store/typewriter-store.test.ts
@@ -37,6 +37,7 @@ describe("TypewriterStore", () => {
 
     expect(result.current.lines).toHaveLength(1)
     expect(result.current.lines[0].text).toBe("Test line")
+    expect(typeof result.current.lines[0].id).toBe("string")
     expect(result.current.activeLine).toBe("")
   })
 

--- a/hooks/useVisibleLines.ts
+++ b/hooks/useVisibleLines.ts
@@ -61,7 +61,7 @@ export function useVisibleLines(
     return lines.slice(start, start + visibleCount).map((line, idx) => ({
       line: parseLine(line.text),
       index: start + idx,
-      key: String(line.id),
+      key: line.id,
     }))
   }, [lines, maxVisibleLines, offset])
 }

--- a/store/typewriter-store.ts
+++ b/store/typewriter-store.ts
@@ -32,8 +32,6 @@ const initialState: Omit<
   flowMode: false, // Neuer Zustand für den Flow Mode
 }
 
-let nextLineId = 1
-
 /**
  * @function useTypewriterStore
  * @description Der zentrale Zustand-Store für die Typewriter-Anwendung, implementiert mit Zustand.
@@ -144,7 +142,7 @@ export const useTypewriterStore = create<TypewriterState & TypewriterActions>()(
 
             const newLines: Line[] = [
               ...lines,
-              { id: nextLineId++, text: lineToAdd },
+              { id: crypto.randomUUID(), text: lineToAdd },
             ]
             set({
               lines: newLines,
@@ -201,7 +199,7 @@ export const useTypewriterStore = create<TypewriterState & TypewriterActions>()(
         }
         const newLines: Line[] = [
           ...lines,
-          { id: nextLineId++, text: activeLine },
+          { id: crypto.randomUUID(), text: activeLine },
         ]
         const newText = newLines.map((l) => l.text).join("\n")
         set({
@@ -261,7 +259,6 @@ export const useTypewriterStore = create<TypewriterState & TypewriterActions>()(
        * Setzt die gesamte Sitzung auf den initialen Zustand zurück.
        */
       resetSession: () => {
-        nextLineId = 1
         set({ ...initialState, containerWidth: get().containerWidth })
       },
 
@@ -373,7 +370,7 @@ export const useTypewriterStore = create<TypewriterState & TypewriterActions>()(
             const newLinesStrings = result.text.split("\n")
             const newActiveLine = newLinesStrings.pop() || ""
             const lineObjects: Line[] = newLinesStrings.map((text) => ({
-              id: nextLineId++,
+              id: crypto.randomUUID(),
               text,
             }))
             set({
@@ -411,7 +408,7 @@ export const useTypewriterStore = create<TypewriterState & TypewriterActions>()(
           if (state.lines && state.lines.length > 0) {
             if (typeof state.lines[0] === "string") {
               state.lines = (state.lines as unknown as string[]).map((text) => ({
-                id: nextLineId++,
+                id: crypto.randomUUID(),
                 text,
               }))
             } else if (
@@ -419,15 +416,15 @@ export const useTypewriterStore = create<TypewriterState & TypewriterActions>()(
               state.lines[0] !== null
             ) {
               state.lines = (state.lines as any[]).map((line) => ({
-                id: typeof line.id === "number" ? line.id : nextLineId++,
+                id:
+                  typeof line.id === "string"
+                    ? line.id
+                    : typeof line.id === "number"
+                      ? String(line.id)
+                      : crypto.randomUUID(),
                 text: typeof line.text === "string" ? line.text : "",
               }))
             }
-            const maxId = (state.lines as Line[]).reduce(
-              (max, line) => Math.max(max, line.id),
-              0,
-            )
-            nextLineId = maxId + 1
           }
           // Stelle sicher, dass flowMode nach dem Laden existiert
           if (typeof state.flowMode === "undefined") {

--- a/types.ts
+++ b/types.ts
@@ -33,7 +33,7 @@ export interface ParagraphRange {
  */
 export interface Line {
   /** Eindeutige ID der Zeile */
-  id: number
+  id: string
   /** Der Textinhalt der Zeile */
   text: string
 }


### PR DESCRIPTION
## Summary
- change `Line.id` type to string
- generate line IDs with `crypto.randomUUID()`
- adjust helpers and tests for string IDs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68960808f55c832288a7692357235211