### PR TITLE
fix: enforce fixed height for ActiveInput

### DIFF
--- a/components/active-input.tsx
+++ b/components/active-input.tsx
@@ -4,8 +4,13 @@ import * as React from "react"
 import { cn } from "@/lib/utils"
 
 const ActiveInput = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn(className)} {...props} />
+  ({ className, style, ...props }, ref) => (
+    <div
+      ref={ref}
+      style={{ ...style, height: "var(--lineHpx)", lineHeight: "var(--lineHpx)" }}
+      className={cn(className)}
+      {...props}
+    />
   )
 )
 ActiveInput.displayName = "ActiveInput"


### PR DESCRIPTION
## Summary
- enforce fixed height in ActiveInput using `var(--lineHpx)`
- allow external styles via `className` without overriding fixed height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68960809a8608322b632866030a7b265