### PR TITLE
Use small viewport height in fullscreen elements

### DIFF
--- a/components/fullscreen-settings.tsx
+++ b/components/fullscreen-settings.tsx
@@ -78,7 +78,7 @@ export default function FullscreenSettings({ isOpen, onClose }: FullscreenSettin
   // Content-Bereich
   const content = document.createElement("div")
   content.className = "p-6 space-y-8 overflow-y-auto"
-  content.style.height = "calc(100vh - 70px)"
+  content.style.height = "calc(100svh - 70px)"
 
   // Füge den Inhalt hinzu (vereinfacht)
   content.innerHTML = `

--- a/components/settings-modal.tsx
+++ b/components/settings-modal.tsx
@@ -81,7 +81,7 @@ export default function SettingsModal({ isOpen, onClose, darkMode }: SettingsMod
       <div
         className="p-6 space-y-8 overflow-auto"
         style={{
-          height: "calc(100vh - 70px)",
+          height: "calc(100svh - 70px)",
           color: darkMode ? "#f9fafb" : "#111827",
         }}
       >

--- a/components/settings-panel.tsx
+++ b/components/settings-panel.tsx
@@ -133,7 +133,7 @@ export default function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
     // Content
     const content = document.createElement("div")
     content.className = "p-6 space-y-8"
-    content.style.height = "calc(100vh - 70px)"
+    content.style.height = "calc(100svh - 70px)"
     content.style.overflow = "auto"
     content.style.color = darkMode ? "#f9fafb" : "#111827"
 

--- a/styles/fullscreen-optimizations.css
+++ b/styles/fullscreen-optimizations.css
@@ -13,7 +13,7 @@
 /* Optimierungen für Android im Vollbildmodus */
 .android-typewriter.fullscreen .writing-container {
   /* Maximale Höhe für Android im Vollbildmodus */
-  height: calc(100vh - 120px) !important;
+  height: calc(100svh - 120px) !important;
 }
 
 /* Verbesserte Sichtbarkeit der aktiven Zeile im Vollbildmodus */


### PR DESCRIPTION
## Summary
- use `100svh` instead of `100vh` for fullscreen layouts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896080996e883229a6b1ff6ac8f3bec