### PR TITLE
Rename typing/navigating modes to write/nav

### DIFF
--- a/__tests__/store/typewriter-store.test.ts
+++ b/__tests__/store/typewriter-store.test.ts
@@ -13,7 +13,7 @@ describe("TypewriterStore", () => {
 
     expect(result.current.lines).toEqual([])
     expect(result.current.activeLine).toBe("")
-    expect(result.current.mode).toBe("typing")
+    expect(result.current.mode).toBe("write")
     expect(result.current.selectedLineIndex).toBeNull()
   })
 
@@ -52,10 +52,11 @@ describe("TypewriterStore", () => {
     })
 
     act(() => {
+      result.current.setMode("nav")
       result.current.adjustOffset(1)
     })
 
-    expect(result.current.mode).toBe("navigating")
+    expect(result.current.mode).toBe("nav")
     expect(result.current.offset).toBe(1)
 
     act(() => {
@@ -95,7 +96,7 @@ describe("TypewriterStore", () => {
     act(() => {
       result.current.setActiveLine("Test line")
       result.current.addLineToStack()
-      result.current.setMode("navigating")
+      result.current.setMode("nav")
       result.current.setSelectedLineIndex(0)
     })
 
@@ -106,7 +107,7 @@ describe("TypewriterStore", () => {
 
     expect(result.current.lines).toEqual([])
     expect(result.current.activeLine).toBe("")
-    expect(result.current.mode).toBe("typing")
+    expect(result.current.mode).toBe("write")
     expect(result.current.selectedLineIndex).toBeNull()
   })
 })

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,8 +39,7 @@ export default function TypewriterPage() {
     selectedLineIndex,
     offset,
     adjustOffset,
-    navigateForward,
-    navigateBackward,
+    setMode,
     resetNavigation,
     flowMode,
     startFlowMode,
@@ -127,7 +126,7 @@ export default function TypewriterPage() {
   // Modul 4: Rückkehr zur aktuellen Schreibposition bei Eingabe
   useEffect(() => {
     // Wenn wir in den Schreibmodus zurückkehren, fokussiere das Eingabefeld
-    if (mode === "typing" && selectedLineIndex === null) {
+    if (mode === "write" && selectedLineIndex === null) {
       focusInput()
     }
   }, [mode, selectedLineIndex, focusInput])
@@ -160,21 +159,30 @@ export default function TypewriterPage() {
       }
       lastKeyRef.current = { key: event.key, time: now }
 
-      if (event.key.startsWith("Arrow")) {
+      if (event.key === "Escape") {
         event.preventDefault()
-        showTemporaryNavigationHint()
-        if (event.key === "ArrowUp") adjustOffset(-1)
-        if (event.key === "ArrowDown") adjustOffset(1)
-        if (event.key === "ArrowLeft") navigateBackward(10)
-        if (event.key === "ArrowRight") navigateForward(10)
+        resetNavigation()
+        focusInput()
         return
       }
 
-      if (mode === "navigating") {
-        if (event.key === "Escape" || event.key === "Enter") {
+      if (event.key === "ArrowUp" || event.key === "ArrowDown") {
+        event.preventDefault()
+        showTemporaryNavigationHint()
+        setMode("nav")
+        adjustOffset(event.key === "ArrowUp" ? -1 : 1)
+        return
+      }
+
+      if (mode === "nav") {
+        if (
+          event.key.length === 1 ||
+          event.key === "Backspace" ||
+          event.key === "Enter"
+        ) {
           event.preventDefault()
           resetNavigation()
-          focusInput() // Fokus nach Beenden der Navigation wiederherstellen
+          handleKeyPress(event.key)
         }
         return
       }
@@ -198,8 +206,7 @@ export default function TypewriterPage() {
   }, [
     mode,
     adjustOffset,
-    navigateForward,
-    navigateBackward,
+    setMode,
     resetNavigation,
     handleKeyPress,
     showTemporaryNavigationHint,
@@ -308,7 +315,7 @@ export default function TypewriterPage() {
 
       {/* Offline-Indikator */}
       <OfflineIndicator darkMode={darkMode} />
-      {mode === "navigating" && showNavigationHint && (
+      {mode === "nav" && showNavigationHint && (
         <div
           className={`fixed bottom-4 left-1/2 transform -translate-x-1/2 py-1 px-2 rounded-full z-50 ${
             darkMode ? "bg-gray-800 text-gray-200" : "bg-white text-gray-800"
@@ -316,7 +323,7 @@ export default function TypewriterPage() {
           role="status"
           aria-live="polite"
         >
-          <span className="font-medium">ESC/Enter zum Beenden</span>
+          <span className="font-medium">ESC zum Beenden</span>
         </div>
       )}
       <SettingsModal isOpen={showSettings} onClose={closeSettings} darkMode={darkMode} />

--- a/components/debug-info.tsx
+++ b/components/debug-info.tsx
@@ -7,7 +7,7 @@ interface DebugInfoProps {
   containerWidth: number
   fontSize: number
   darkMode: boolean
-  mode: "typing" | "navigating"
+  mode: "write" | "nav"
   selectedLineIndex: number | null
   scrollPosition: number
 }

--- a/components/navigation-indicator.tsx
+++ b/components/navigation-indicator.tsx
@@ -10,10 +10,10 @@ interface NavigationIndicatorProps {
  * Zeigt einen Indikator für die aktuelle Navigation an
  */
 export default function NavigationIndicator({ darkMode }: NavigationIndicatorProps) {
-  const { mode, selectedLineIndex, lines } = useTypewriterStore()
+  const { mode } = useTypewriterStore()
 
-  // Wenn wir nicht im Navigationsmodus sind oder keine Zeile ausgewählt ist, zeige nichts an
-  if (mode !== "navigating" || selectedLineIndex === null) return null
+  // Nur im Navigationsmodus anzeigen
+  if (mode !== "nav") return null
 
   return (
     <div
@@ -21,9 +21,7 @@ export default function NavigationIndicator({ darkMode }: NavigationIndicatorPro
         darkMode ? "bg-gray-800 text-gray-200" : "bg-white text-gray-800"
       }`}
     >
-      <div className="text-sm font-medium">
-        Zeile {selectedLineIndex + 1} von {lines.length}
-      </div>
+      <div className="text-sm font-medium">Navigationsmodus</div>
     </div>
   )
 }

--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -21,7 +21,7 @@ interface WritingAreaProps {
   activeLine: string
   stackFontSize: number
   darkMode: boolean
-  mode: "typing" | "navigating"
+  mode: "write" | "nav"
   offset: number
   isFullscreen: boolean
   linesContainerRef?: React.RefObject<HTMLDivElement | null>

--- a/components/writing-area/LineStack.tsx
+++ b/components/writing-area/LineStack.tsx
@@ -2,7 +2,7 @@ import { memo, CSSProperties } from "react"
 
 interface LineStackProps {
   visibleLines: { line: { text: string }; index: number; key: string }[]
-  mode: "typing" | "navigating"
+  mode: "write" | "nav"
   lineHpx?: number
 }
 
@@ -20,7 +20,7 @@ export const LineStack = memo(function LineStack({
         flexDirection: "column",
         // Beginne im Tippmodus oben links, damit die erste Zeile an der Oberkante startet
         // und neue Zeilen darunter erscheinen
-        justifyContent: mode === "navigating" ? "center" : "flex-start",
+        justifyContent: mode === "nav" ? "center" : "flex-start",
         maxHeight: "100%",
         lineHeight: "var(--lineHpx)",
         gap: "0",

--- a/hooks/use-keyboard-navigation.ts
+++ b/hooks/use-keyboard-navigation.ts
@@ -54,7 +54,7 @@ export function useKeyboardNavigation({
 
   // Fokussiere das Eingabefeld, wenn wir in den Schreibmodus zurückkehren
   useEffect(() => {
-    if (mode === "typing" && selectedLineIndex === null) {
+    if (mode === "write" && selectedLineIndex === null) {
       focusInput()
     }
   }, [mode, selectedLineIndex, focusInput])

--- a/store/typewriter-store.ts
+++ b/store/typewriter-store.ts
@@ -25,7 +25,7 @@ const initialState: Omit<
   paragraphRanges: [],
   inParagraph: false,
   currentParagraphStart: 0,
-  mode: "typing",
+  mode: "write",
   selectedLineIndex: null,
   offset: 0,
   maxVisibleLines: 0,
@@ -274,9 +274,9 @@ export const useTypewriterStore = create<TypewriterState & TypewriterActions>()(
       },
 
       /**
-       * Setzt den Anwendungsmodus ('typing' oder 'navigating').
-       * @param {"typing" | "navigating"} mode - Der neue Modus.
-       */
+       * Setzt den Anwendungsmodus ('write' oder 'nav').
+       * @param {"write" | "nav"} mode - Der neue Modus.
+      */
       setMode: (mode) => set({ mode }),
 
       /**
@@ -298,46 +298,30 @@ export const useTypewriterStore = create<TypewriterState & TypewriterActions>()(
         const allLines = [...lines, activeLine]
         const maxOffset = Math.max(allLines.length - maxVisibleLines, 0)
         const newOffset = Math.min(Math.max(offset + delta, 0), maxOffset)
-        set({ mode: "navigating", offset: newOffset })
+        set({ offset: newOffset })
       },
 
       /**
        * Navigiert eine Zeile nach oben im Stack.
        */
-      navigateUp: () => get().adjustOffset(-1),
+      navigateUp: () => {
+        set({ mode: "nav" })
+        get().adjustOffset(-1)
+      },
 
       /**
        * Navigiert eine Zeile nach unten im Stack oder beendet den Navigationsmodus.
        */
-      navigateDown: () => get().adjustOffset(1),
-
-      /**
-       * Springt mehrere Zeilen vorwärts.
-       * @param {number} count - Die Anzahl der zu springenden Zeilen.
-       */
-      navigateForward: (count: number) => {
-        const { lines, selectedLineIndex } = get()
-        if (selectedLineIndex === null) return
-        const newIndex = Math.min(lines.length - 1, selectedLineIndex + count)
-        set({ selectedLineIndex: newIndex })
+      navigateDown: () => {
+        set({ mode: "nav" })
+        get().adjustOffset(1)
       },
 
-      /**
-       * Springt mehrere Zeilen rückwärts.
-       * @param {number} count - Die Anzahl der zu springenden Zeilen.
-       */
-      navigateBackward: (count: number) => {
-        const { selectedLineIndex } = get()
-        if (selectedLineIndex === null) return
-        const newIndex = Math.max(0, selectedLineIndex - count)
-        set({ selectedLineIndex: newIndex })
-      },
-
-      /**
-       * Beendet den Navigationsmodus und kehrt zum Schreibmodus zurück.
-       */
-      resetNavigation: () => {
-        set({ mode: "typing", selectedLineIndex: null, offset: 0 })
+        /**
+         * Beendet den Navigationsmodus und kehrt zum Schreibmodus zurück.
+         */
+        resetNavigation: () => {
+          set({ mode: "write", selectedLineIndex: null, offset: 0 })
       },
 
       /**

--- a/types.ts
+++ b/types.ts
@@ -137,7 +137,7 @@ export interface TypewriterState {
   /** Startindex des aktuellen Absatzes (für Abwärtskompatibilität) */
   currentParagraphStart: number
   /** Aktueller Modus (Schreiben oder Navigieren) */
-  mode: "typing" | "navigating"
+  mode: "write" | "nav"
   /** Index der aktuell ausgewählten Zeile (null, wenn keine ausgewählt ist) */
   selectedLineIndex: number | null
   /** Aktueller Versatz für die Anzeige der Zeilen */
@@ -181,7 +181,7 @@ export interface TypewriterActions {
   /** Funktion zum Setzen einer festen Zeilenlänge */
   setFixedLineLength: (length: number) => void
   /** Funktion zum Setzen des Modus */
-  setMode: (mode: "typing" | "navigating") => void
+  setMode: (mode: "write" | "nav") => void
   /** Funktion zum Setzen des ausgewählten Zeilenindex */
   setSelectedLineIndex: (index: number | null) => void
   /** Aktualisiert die maximale Anzahl sichtbarer Zeilen */
@@ -192,10 +192,6 @@ export interface TypewriterActions {
   navigateUp: () => void
   /** Funktion zum Navigieren nach unten im Stack */
   navigateDown: () => void
-  /** Funktion zum Navigieren vorwärts (mehrere Zeilen) */
-  navigateForward: (count: number) => void
-  /** Funktion zum Navigieren rückwärts (mehrere Zeilen) */
-  navigateBackward: (count: number) => void
   /** Funktion zum Zurücksetzen der Navigation */
   resetNavigation: () => void
   /** Funktion zum Speichern der aktuellen Sitzung */


### PR DESCRIPTION
## Summary
- rename `typing`/`navigating` modes to `write`/`nav`
- add global navigation behavior: ArrowUp/ArrowDown enter nav mode, text input or Escape return to write
- clean up store navigation functions and update components and tests

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6896080b25dc8322b09ff9f179375c75