### PR TITLE
docs: add Playwright E2E test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,20 @@ npx jest --watch
 npx jest --coverage
 ```
 
+### End-to-End Tests
+
+Für browserbasierte E2E-Tests kommt [Playwright](https://playwright.dev/) zum Einsatz. Vor dem ersten Lauf müssen die benötigten Browser installiert werden:
+
+```bash
+npx playwright install
+```
+
+Die Tests können anschließend mit folgendem Befehl ausgeführt werden:
+
+```bash
+npm run test:e2e
+```
+
 Die Tests befinden sich im Verzeichnis `__tests__/`.
 
 ## Sicherheit


### PR DESCRIPTION
## Summary
- document how to install Playwright browsers
- show command to run end-to-end tests

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68961496cdfc83228fe5f64c92d1ef6a