### PR TITLE
Fix arrow key navigation direction

### DIFF
--- a/__tests__/store/typewriter-store.test.ts
+++ b/__tests__/store/typewriter-store.test.ts
@@ -67,6 +67,30 @@ describe("TypewriterStore", () => {
     expect(result.current.offset).toBe(0)
   })
 
+  it("should navigate up and down through lines", () => {
+    const { result } = renderHook(() => useTypewriterStore())
+
+    act(() => {
+      result.current.setActiveLine("Line 1")
+      result.current.addLineToStack()
+      result.current.setActiveLine("Line 2")
+      result.current.addLineToStack()
+      result.current.setMaxVisibleLines(1)
+    })
+
+    act(() => {
+      result.current.navigateUp()
+    })
+
+    expect(result.current.offset).toBe(1)
+
+    act(() => {
+      result.current.navigateDown()
+    })
+
+    expect(result.current.offset).toBe(0)
+  })
+
   it("should update line break config", () => {
     const { result } = renderHook(() => useTypewriterStore())
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -170,7 +170,7 @@ export default function TypewriterPage() {
         event.preventDefault()
         showTemporaryNavigationHint()
         setMode("nav")
-        adjustOffset(event.key === "ArrowUp" ? -1 : 1)
+        adjustOffset(event.key === "ArrowUp" ? 1 : -1)
         return
       }
 

--- a/store/typewriter-store.ts
+++ b/store/typewriter-store.ts
@@ -303,7 +303,7 @@ export const useTypewriterStore = create<TypewriterState & TypewriterActions>()(
        */
       navigateUp: () => {
         set({ mode: "nav" })
-        get().adjustOffset(-1)
+        get().adjustOffset(1)
       },
 
       /**
@@ -311,7 +311,7 @@ export const useTypewriterStore = create<TypewriterState & TypewriterActions>()(
        */
       navigateDown: () => {
         set({ mode: "nav" })
-        get().adjustOffset(1)
+        get().adjustOffset(-1)
       },
 
         /**


### PR DESCRIPTION
## Summary
- Reverse ArrowUp/ArrowDown behavior to show older lines when pressing up
- Update navigateUp/navigateDown to match new offset direction
- Add store tests for line navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896ff63a634832294594473ca85e7cc