### PR TITLE
Measure active line width minus padding

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -215,16 +215,24 @@ export default function TypewriterPage() {
 
   const openSettings = useCallback(() => setShowSettings(true), [])
 
-  // Aktualisiere die Breite des Textcontainers
+  // Aktualisiere die verfügbare Breite der aktiven Zeile (ohne Padding)
   useEffect(() => {
     const updateWidth = () => {
-      if (linesContainerRef.current) {
-        setContainerWidth(linesContainerRef.current.clientWidth)
+      if (activeLineRef.current) {
+        const element = activeLineRef.current
+        const style = getComputedStyle(element)
+        const available =
+          element.clientWidth -
+          parseFloat(style.paddingLeft) -
+          parseFloat(style.paddingRight)
+        if (available > 0) {
+          setContainerWidth(available)
+        }
       }
     }
     updateWidth()
     const observer = new ResizeObserver(updateWidth)
-    if (linesContainerRef.current) observer.observe(linesContainerRef.current)
+    if (activeLineRef.current) observer.observe(activeLineRef.current)
     return () => observer.disconnect()
   }, [setContainerWidth])
 

--- a/store/typewriter-store.ts
+++ b/store/typewriter-store.ts
@@ -111,8 +111,8 @@ export const useTypewriterStore = create<TypewriterState & TypewriterActions>()(
           }
 
           const font = `${fontSize}px "Lora", serif`
-          // The containerWidth from the store is now the clientWidth of the text area,
-          // which already accounts for padding. No subtraction needed.
+          // containerWidth enthält bereits die nutzbare Breite der aktiven Zeile
+          // (clientWidth abzüglich horizontalem Padding)
           const availableWidth = containerWidth
           const textWidth = measureTextWidth(newActiveLineContent, font)
 
@@ -158,9 +158,9 @@ export const useTypewriterStore = create<TypewriterState & TypewriterActions>()(
       },
 
       /**
-       * Aktualisiert die Breite des Schreib-Containers.
+       * Aktualisiert die verfügbare Breite des Schreib-Containers (ohne horizontales Padding).
        * Wichtig für die Berechnung des automatischen Zeilenumbruchs.
-       * @param {number} width - Die neue Breite des Containers in Pixeln.
+       * @param {number} width - Die nutzbare Breite des Containers in Pixeln.
       */
       setContainerWidth: (width: number) => set({ containerWidth: width }),
 


### PR DESCRIPTION
## Summary
- compute available width from the active line element, subtracting horizontal padding, and store it for layout
- clarify container width handling in store to reflect padding-adjusted measurement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896ff88b728832295062268deab5ec0