### PR TITLE
Reset navigation after new lines and wraps

### DIFF
--- a/store/typewriter-store.ts
+++ b/store/typewriter-store.ts
@@ -148,6 +148,8 @@ export const useTypewriterStore = create<TypewriterState & TypewriterActions>()(
               lines: newLines,
               activeLine: remainder,
               offset: 0,
+              mode: "write",
+              selectedLineIndex: null,
               statistics: calculateTextStatistics([
                 ...newLines.map((l) => l.text),
                 remainder,
@@ -206,6 +208,8 @@ export const useTypewriterStore = create<TypewriterState & TypewriterActions>()(
           lines: newLines,
           activeLine: "",
           offset: 0,
+          mode: "write",
+          selectedLineIndex: null,
           statistics: calculateTextStatistics(newText),
         })
       },


### PR DESCRIPTION
## Summary
- reset navigation mode on automatic line wraps
- ensure addLineToStack returns to write mode and clears selection
- keep cursor at end after hard wraps or Enter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896ff8d5b988322bb9d269db485c688