### PR TITLE
Remove overlays from writing area

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,8 @@ import OptionsBar from "@/components/options-bar"
 import ActiveInput from "@/components/active-input"
 import { ActiveLine } from "@/components/writing-area/ActiveLine"
 import NavigationIndicator from "@/components/navigation-indicator"
+import { CopyButton } from "@/components/writing-area/CopyButton"
+import { NavigationHint } from "@/components/writing-area/NavigationHint"
 import { useAndroidKeyboard } from "@/hooks/useAndroidKeyboard"
 import { useResponsiveTypography } from "@/hooks/useResponsiveTypography"
 import { useMaxVisibleLines } from "@/hooks/useMaxVisibleLines"
@@ -280,7 +282,6 @@ export default function TypewriterPage() {
       <div className="flex-1 overflow-hidden">
         <WritingArea
           lines={lines}
-          activeLine={activeLine}
           stackFontSize={stackFontSize}
           darkMode={darkMode}
           mode={mode}
@@ -307,6 +308,11 @@ export default function TypewriterPage() {
           isFullscreen={isFullscreen}
         />
       </ActiveInput>
+
+      <div className="flex justify-between px-4 py-2">
+        <NavigationHint darkMode={darkMode} />
+        <CopyButton lines={lines} activeLine={activeLine} darkMode={darkMode} />
+      </div>
 
       <NavigationIndicator darkMode={darkMode} />
       <SaveNotification />

--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -6,8 +6,6 @@ import type { Line } from "@/types"
 
 import { useVisibleLines } from "@/hooks/useVisibleLines"
 import { useTypewriterStore } from "@/store/typewriter-store"
-import { CopyButton } from "./writing-area/CopyButton"
-import { NavigationHint } from "./writing-area/NavigationHint"
 import { LineStack } from "./writing-area/LineStack"
 
 /**
@@ -18,7 +16,6 @@ import { LineStack } from "./writing-area/LineStack"
  */
 interface WritingAreaProps {
   lines: Line[]
-  activeLine: string
   stackFontSize: number
   darkMode: boolean
   mode: "write" | "nav"
@@ -36,7 +33,6 @@ interface WritingAreaProps {
  */
 export default function WritingArea({
   lines,
-  activeLine,
   stackFontSize,
   darkMode,
   mode,
@@ -73,9 +69,6 @@ export default function WritingArea({
 
   return (
     <div className="flex-1 flex flex-col relative overflow-hidden font-serif">
-      <CopyButton lines={lines} activeLine={activeLine} darkMode={darkMode} />
-      <NavigationHint darkMode={darkMode} />
-
       <div
         ref={setLinesContainerRef}
         className={`flex-1 overflow-hidden px-4 md:px-6 pt-6 writing-container flex flex-col justify-start ${

--- a/components/writing-area/CopyButton.tsx
+++ b/components/writing-area/CopyButton.tsx
@@ -33,7 +33,7 @@ export function CopyButton({ lines, activeLine, darkMode }: CopyButtonProps) {
   return (
     <button
       onClick={copyAllText}
-      className={`absolute top-2 right-2 z-20 p-2 rounded-full ${
+      className={`p-2 rounded-full ${
         darkMode ? "bg-gray-700 text-gray-200 hover:bg-gray-600" : "bg-gray-200 text-gray-800 hover:bg-gray-300"
       }`}
       aria-label="Gesamten Text kopieren"

--- a/components/writing-area/NavigationHint.tsx
+++ b/components/writing-area/NavigationHint.tsx
@@ -1,7 +1,5 @@
 "use client"
 
-import { useState, useEffect } from "react"
-
 interface NavigationHintProps {
   darkMode: boolean
 }
@@ -10,26 +8,11 @@ interface NavigationHintProps {
  * Komponente für den Pfeiltasten-Hinweis
  */
 export function NavigationHint({ darkMode }: NavigationHintProps) {
-  const [isVisible, setIsVisible] = useState(false)
-
-  useEffect(() => {
-    const handleMouseMove = (e: MouseEvent) => {
-      // Zeige den Hinweis nur, wenn die Maus im oberen Bereich des Fensters ist
-      const topThreshold = window.innerHeight * 0.15 // Obere 15% des Fensters
-      setIsVisible(e.clientY < topThreshold)
-    }
-
-    window.addEventListener("mousemove", handleMouseMove)
-    return () => {
-      window.removeEventListener("mousemove", handleMouseMove)
-    }
-  }, [])
-
   return (
     <div
-      className={`absolute top-2 left-2 z-20 p-2 rounded-lg ${
+      className={`p-2 rounded-lg ${
         darkMode ? "bg-gray-700 text-gray-200" : "bg-gray-200 text-gray-800"
-      } text-xs transition-opacity duration-300 ${isVisible ? "opacity-80" : "opacity-0"}`}
+      } text-xs opacity-80`}
     >
       <div className="flex flex-col gap-1">
         <span>↑↓ Zeilen navigieren</span>


### PR DESCRIPTION
## Summary
- move copy and navigation hint controls below the active line
- simplify CopyButton and NavigationHint components to avoid absolute positioning
- adjust WritingArea to render only line stacks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896ff6ddd4483228017dc0b05997722