### PR TITLE
feat: tweak active line whitespace handling

### DIFF
--- a/utils/lineClassUtils.ts
+++ b/utils/lineClassUtils.ts
@@ -1,3 +1,3 @@
 export function getActiveLineTextClass(darkMode: boolean): string {
-  return `whitespace-pre-wrap break-words absolute top-0 left-0 pointer-events-none overflow-hidden ${darkMode ? "text-gray-200" : "text-gray-800"}`
+  return `whitespace-pre absolute top-0 left-0 pointer-events-none overflow-hidden ${darkMode ? "text-gray-200" : "text-gray-800"}`
 }


### PR DESCRIPTION
## Summary
- replace `whitespace-pre-wrap break-words` with `whitespace-pre` so active line no longer soft-wraps
- ensure active line text still uses `overflow-hidden`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896ff8a35208322bb1f795868d8731f