### PR TITLE
feat: centralize OptionsBar positioning

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -272,7 +272,7 @@ export default function TypewriterPage() {
 
       <OptionsBar
         ref={headerRef}
-        className={`w-screen min-h-[40px] max-h-[10vh] shrink-0 border-b ${
+        className={`min-h-[40px] max-h-[10vh] shrink-0 border-b ${
           darkMode ? "border-gray-700" : isFullscreen ? "border-[#e0dcd3]" : "border-[#d3d0cb]"
         } transition-colors duration-300`}
       >

--- a/components/options-bar.tsx
+++ b/components/options-bar.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils"
 
 const OptionsBar = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn(className)} {...props} />
+    <div ref={ref} className={cn("sticky top-0 w-full", className)} {...props} />
   )
 )
 OptionsBar.displayName = "OptionsBar"


### PR DESCRIPTION
## Summary
- give `OptionsBar` default positioning classes for sticky full-width placement
- remove redundant width styling from `TypewriterPage` while keeping existing height limits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689704eab0d48322b0ebb0baf59e02b6