### PR TITLE
Anchor LineStack lines to top in all modes

### DIFF
--- a/__tests__/app/line-stack.test.tsx
+++ b/__tests__/app/line-stack.test.tsx
@@ -1,0 +1,22 @@
+import { render } from "@testing-library/react"
+import { LineStack } from "@/components/writing-area/LineStack"
+
+describe("LineStack", () => {
+  const sampleLines = [{ line: { text: "Zeile 1" }, index: 0, key: "0" }]
+
+  it("anchors lines at the top in write mode", () => {
+    const { container } = render(
+      <LineStack visibleLines={sampleLines} mode="write" />,
+    )
+    const stack = container.querySelector(".line-stack") as HTMLElement
+    expect(stack.style.justifyContent).toBe("flex-start")
+  })
+
+  it("anchors lines at the top in navigation mode", () => {
+    const { container } = render(
+      <LineStack visibleLines={sampleLines} mode="nav" />,
+    )
+    const stack = container.querySelector(".line-stack") as HTMLElement
+    expect(stack.style.justifyContent).toBe("flex-start")
+  })
+})

--- a/components/writing-area/LineStack.tsx
+++ b/components/writing-area/LineStack.tsx
@@ -18,9 +18,9 @@ export const LineStack = memo(function LineStack({
         overflow: "hidden",
         display: "flex",
         flexDirection: "column",
-        // Beginne im Tippmodus oben links, damit die erste Zeile an der Oberkante startet
+        // Zeilen immer oben ausrichten, damit die erste Zeile an der Oberkante startet
         // und neue Zeilen darunter erscheinen
-        justifyContent: mode === "nav" ? "center" : "flex-start",
+        justifyContent: "flex-start",
         maxHeight: "100%",
         lineHeight: "var(--lineHpx)",
         gap: "0",


### PR DESCRIPTION
## Summary
- Always align lines at the top by setting `justifyContent: "flex-start"` in `LineStack`
- Verify top-edge alignment for write and navigation modes with new tests

## Testing
- `npm test`
- `npm run lint` (warnings: React Hook useEffect dependency)


------
https://chatgpt.com/codex/tasks/task_e_689704f2b2088322bc25c70965752570